### PR TITLE
emit tail sizeof as symbol and alloc accordingly in wrappers

### DIFF
--- a/modules/err/src/lib.zz
+++ b/modules/err/src/lib.zz
@@ -5,6 +5,7 @@ using <stdlib.h>::{abort as cabort};
 using <stdarg.h>::{va_list, va_start, va_end};
 using string::{String};
 using string;
+using log;
 
 pub theory checked(Err * self) -> bool;
 
@@ -119,8 +120,9 @@ model checked(*self)
 
 export fn eprint(Err+tail mut* self)
 {
-    fprintf(stderr, "error %u: %s%s\n", self->error, self->description, (self->locations).mem);
+    log::error("%u: %s%s\n", self->error, self->description, (self->locations).mem);
 }
+
 
 export fn to_str(
     Err * self,

--- a/modules/err/zz.toml
+++ b/modules/err/zz.toml
@@ -4,3 +4,4 @@ name = "err"
 
 [dependencies]
 string = "1"
+log  = "1"

--- a/modules/log/src/lib.zz
+++ b/modules/log/src/lib.zz
@@ -1,60 +1,30 @@
 using <stdarg.h>::{va_list, va_start, va_end};
 using <stdio.h>::{vfprintf, fprintf, stderr};
+inline using "os.h"::{
+    os_zz_log_error,
+    os_zz_log_warn,
+    os_zz_log_info,
+    os_zz_log_debug,
+}
 
 
 export fn error(char * callsite_source<module> module, char *fmt, ...)
 {
-    fprintf(stderr, "[\x1B[31mERR\x1B[0m] %s ", module);
-    va_list mut args;
-    va_start (args, fmt);
-    vfprintf(
-        stderr,
-        fmt,
-        args
-    );
-    va_end (args);
-    fprintf(stderr, "\n");
+    os_zz_log_error(module, fmt);
 }
 
 export fn warn(char * callsite_source<module> module, char *fmt, ...)
 {
-    fprintf(stderr, "[\x1B[33mWRN\x1B[0m] %s ", module);
-    va_list mut args;
-    va_start (args, fmt);
-    vfprintf(
-        stderr,
-        fmt,
-        args
-    );
-    va_end (args);
-    fprintf(stderr, "\n");
+    os_zz_log_warn(module, fmt);
 }
 
 export fn info(char * callsite_source<module> module, char *fmt, ...)
 {
-    fprintf(stderr, "[\x1B[32mINF\x1B[0m] %s ", module);
-    va_list mut args;
-    va_start (args, fmt);
-    vfprintf(
-        stderr,
-        fmt,
-        args
-    );
-    va_end (args);
-    fprintf(stderr, "\n");
+    os_zz_log_info(module, fmt);
 }
 
 export fn debug(char * callsite_source<module> module, char *fmt, ...)
 {
-    fprintf(stderr, "[\x1B[36mDBG\x1B[0m] %s ", module);
-    va_list mut args;
-    va_start (args, fmt);
-    vfprintf(
-        stderr,
-        fmt,
-        args
-    );
-    va_end (args);
-    fprintf(stderr, "\n");
+    os_zz_log_debug(module, fmt);
 }
 

--- a/modules/log/src/os.h
+++ b/modules/log/src/os.h
@@ -1,0 +1,84 @@
+#include <stdarg.h>
+#include <stdio.h>
+
+
+#if defined(__ANDROID__)
+#include <android/log.h>
+
+#define os_zz_log_error(mod, fmt) \
+    va_list args; \
+    va_start (args, fmt); \
+    __android_log_vprint( ANDROID_LOG_ERROR, mod, fmt, args); \
+    va_end (args);
+
+#define os_zz_log_debug(mod, fmt) \
+    va_list args; \
+    va_start (args, fmt); \
+    __android_log_vprint( ANDROID_LOG_DEBUG, mod, fmt, args); \
+    va_end (args);
+
+#define os_zz_log_info(mod, fmt) \
+    va_list args; \
+    va_start (args, fmt); \
+    __android_log_vprint( ANDROID_LOG_INFO, mod, fmt, args); \
+    va_end (args);
+
+#define os_zz_log_warn(mod, fmt) \
+    va_list args; \
+    va_start (args, fmt); \
+    __android_log_vprint( ANDROID_LOG_WARN, mod, fmt, args); \
+    va_end (args);
+
+#else
+
+#define os_zz_log_error(mod, fmt) \
+    fprintf(stderr, "[\x1B[31mERR\x1B[0m] %s ", mod); \
+    va_list args; \
+    va_start (args, fmt); \
+    vfprintf( \
+        stderr, \
+        fmt, \
+        args \
+    ); \
+    va_end (args); \
+    fprintf(stderr, "\n"); \
+
+#define os_zz_log_warn(mod, fmt) \
+    fprintf(stderr, "[\x1B[33mWRN\x1B[0m] %s ", module); \
+    va_list args; \
+    va_start (args, fmt); \
+    vfprintf( \
+        stderr, \
+        fmt, \
+        args \
+    ); \
+    va_end (args); \
+    fprintf(stderr, "\n"); \
+
+#define os_zz_log_info(mod, fmt) \
+    fprintf(stderr, "[\x1B[32mINF\x1B[0m] %s ", module); \
+    va_list args; \
+    va_start (args, fmt); \
+    vfprintf( \
+        stderr, \
+        fmt, \
+        args \
+    ); \
+    va_end (args); \
+    fprintf(stderr, "\n"); \
+
+
+#define os_zz_log_debug(mod, fmt) \
+    fprintf(stderr, "[\x1B[36mDBG\x1B[0m] %s ", module); \
+    va_list args; \
+    va_start (args, fmt); \
+    vfprintf( \
+        stderr, \
+        fmt, \
+        args \
+    ); \
+    va_end (args); \
+    fprintf(stderr, "\n"); \
+
+#endif
+

--- a/src/abs.rs
+++ b/src/abs.rs
@@ -916,7 +916,7 @@ pub fn abs(md: &mut ast::Module, all_modules: &HashMap<Name, loader::Module>, ex
 
                     match field.typed.tail {
                         ast::Tail::None | ast::Tail::Static(_, _) => {},
-                        ast::Tail::Bind(_,_) | ast::Tail::Dynamic => {
+                        ast::Tail::Bind(_,_) | ast::Tail::Dynamic(_) => {
                             if i != fieldslen - 1 {
                                 emit_error(format!("nested tail must be last field"), &[
                                     (field.loc.clone(), format!("field {} is non static tail, but not the last field", field.name)),
@@ -1023,7 +1023,7 @@ fn abs_args(
         match &arg.typed.tail {
             ast::Tail::None => {
             },
-            ast::Tail::Dynamic => {
+            ast::Tail::Dynamic(_) => {
                 emit_error(format!("missing tail binding "), &[
                            (arg.loc.clone(), "+ without a name makes no sense in this context"),
                 ]);

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -79,7 +79,7 @@ pub struct Import {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum Tail {
     None,
-    Dynamic,
+    Dynamic(Option<Box<Typed>> /*final*/),
     Static(u64, Location),
     Bind(String, Location),
 }
@@ -304,7 +304,7 @@ impl std::fmt::Display for Typed{
         }
         match &self.tail {
             Tail::None          => (),
-            Tail::Dynamic       => write!(f, "+")?,
+            Tail::Dynamic(_)    => write!(f, "+")?,
             Tail::Static(v, _)  => write!(f, "+{}", v)?,
             Tail::Bind(v,_)     => write!(f, "+{}", v)?,
         }

--- a/src/emitter_docs.rs
+++ b/src/emitter_docs.rs
@@ -100,7 +100,7 @@ self.module.name.0[1..].join("::")).unwrap();
                 ast::Def::Struct{..} => {
                     self.emit_struct(&d, None);
                     if let Some(vs) = module.typevariants.get(&Name::from(&d.name)) {
-                        for v in vs {
+                        for (v,_) in vs {
                             let mut d = d.clone();
                             d.name = format!("{}_{}", d.name, v);
                             self.emit_struct(&d, Some(*v));

--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -40,7 +40,7 @@ pub struct Module {
     pub aliases:        HashMap<Name, String>,
     pub deps:           HashSet<Name>,
 
-    pub typevariants:   HashMap<Name, HashSet<u64>>,
+    pub typevariants:   HashMap<Name, HashMap<u64, ast::Location>>,
 }
 
 #[derive(Clone)]
@@ -57,7 +57,7 @@ struct Local {
 
 #[derive(Default)]
 struct Collector {
-    typevariants:   HashMap<Name, HashSet<u64>>,
+    typevariants:   HashMap<Name, HashMap<u64, ast::Location>>,
 }
 
 #[derive(Default)]
@@ -91,9 +91,9 @@ fn type_deps(cr: &mut Collector, typed: &ast::Typed) -> Vec<(Name, TypeComplete,
         r.extend(tag_deps(cr, &ptr.tags));
     }
 
-    if let ast::Tail::Static(v,_) = &typed.tail {
+    if let ast::Tail::Static(v,vloc) = &typed.tail {
         if let ast::Type::Other(name) = &typed.t {
-            cr.typevariants.entry(name.clone()).or_default().insert(v.clone());
+            cr.typevariants.entry(name.clone()).or_default().insert(v.clone(), vloc.clone());
         }
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -354,7 +354,7 @@ fn p(n: &Path, features: &HashMap<String, bool> , stage: &Stage) -> Result<Modul
                 for part in PP::new(n,features.clone(), stage.clone(), decl) {
                     match part.as_rule() {
                         Rule::tail => {
-                            tail = Tail::Dynamic;
+                            tail = Tail::Dynamic(None);
                         }
                         Rule::key_packed => {
                             packed = true;
@@ -1382,7 +1382,7 @@ pub(crate) fn parse_named_type(n: &str, decl: pest::iterators::Pair<'static, Rul
                         tail = Tail::Bind(part, loc);
                     }
                 } else {
-                    tail = Tail::Dynamic
+                    tail = Tail::Dynamic(None)
                 }
             },
             e => panic!("unexpected rule {:?} in named_type lhs", e),
@@ -1495,7 +1495,7 @@ pub(crate) fn parse_anon_type(n: &str, decl: pest::iterators::Pair<'static, Rule
                         tail = Tail::Bind(part, loc);
                     }
                 } else {
-                    tail = Tail::Dynamic
+                    tail = Tail::Dynamic(None)
                 }
             },
             e => panic!("unexpected rule {:?} in anon_type", e),

--- a/src/symbolic.rs
+++ b/src/symbolic.rs
@@ -1233,7 +1233,7 @@ impl Symbolic {
 
                 // cast to unsized type for the C compiler to be happy
                 if into_type.tail != ast::Tail::None {
-                    into_type.tail = ast::Tail::Dynamic;
+                    into_type.tail = ast::Tail::Dynamic(None);
                 }
                 *prev = Box::new(ast::Expression::Cast {
                     into: into_type,
@@ -1251,7 +1251,7 @@ impl Symbolic {
                         }));
                         called.push(genarg);
                     }
-                    ast::Tail::Dynamic | ast::Tail::None  => {
+                    ast::Tail::Dynamic(_) | ast::Tail::None  => {
                         return Err(self.trace(format!("tail size of {} not bound", self.memory[callptr].name), vec![
                             (prev_loc.clone(), format!("tail len required here")),
                             (defined[i].loc.clone(), format!("required by this tail binding")),
@@ -1494,7 +1494,7 @@ impl Symbolic {
 
         //nested tail
         match fieldtyped.tail {
-            ast::Tail::Dynamic => {
+            ast::Tail::Dynamic(_) => {
                 fieldtyped.tail = self.memory[lhs_sym].typed.tail.clone();
                 //return Err(self.trace(
                 //    format!("TODO: implement access to nested tail member"), vec![
@@ -2869,7 +2869,7 @@ impl Symbolic {
         self.ssa.debug_loc(loc);
         let tailval = match self.memory[sym].typed.tail.clone() {
             ast::Tail::None     => return Ok(()),
-            ast::Tail::Dynamic  => {
+            ast::Tail::Dynamic(_)  => {
                 return Err(self.trace(format!("tail size must be known for stack variables"), vec![
                     (self.memory[sym].typed.loc.clone(), format!("cannot use dynamic tail size here"))
                 ]));


### PR DESCRIPTION
malloc(sizeof(Thing) + tail) is actually very wrong,
because tail is a number of ITEMS not bytes.

we now emit the size of one of those items as tailsize_Thing
and change wrappers accordingly