### PR TITLE
remove 'new' keyword from 'String::clear()' method

### DIFF
--- a/modules/string/src/lib.zz
+++ b/modules/string/src/lib.zz
@@ -77,7 +77,7 @@ export fn make(String+tail mut new* self)
 }
 
 /// clear the string
-export fn clear(String+tail mut new* self)
+export fn clear(String+tail mut * self)
     model self->len  == 0
     model nullterm(self->mem)
 {


### PR DESCRIPTION
heyoo the `new` keyword in the `clear()` method for the `string` module looks like a typo. This PR removes it