### PR TITLE
remove cloned repo, not entire '___' dir

### DIFF
--- a/src/repos.rs
+++ b/src/repos.rs
@@ -65,16 +65,16 @@ pub fn index(project: &project::Config) -> HashSet<PathBuf> {
                             );
                         }
 
-                        let npx = Path::new("target").join("repos").join("___");
+                        let npx = Path::new("target").join("repos").join("___").join(name.clone());
                         if npx.exists() {
                             std::fs::remove_dir_all(&npx)
                                 .expect(&format!("cannot remove {:?}", npx));
                         }
                         std::fs::create_dir_all(&npx).expect(&format!("cannot create {:?}", npx));
-                        std::fs::rename(&np, npx.join(name.clone())).expect(&format!(
+                        std::fs::rename(&np, &npx).expect(&format!(
                             "cannot move {:?} to {:?}",
                             np,
-                            npx.join(name.clone())
+                            npx
                         ));
                     }
                 }


### PR DESCRIPTION
This PR ensures a cloned repo is removed, not the entire `targets/repos/___` directory. This happens when I list multiple repos in the `[repos]` section of `zz.toml`. Note that both repos do not export a `modules/` directory, but rather the source of a single module.