### PR TITLE
add '.gitattributes' for ZZ source code highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.zz linguist-language=C++


### PR DESCRIPTION
This PR adds a `.gitattributes` file to the root of the repository specifying files with the `.zz` file extension should be treated as `c++` source code. This is a workaround until we can somehow get official syntax highlighting for ZZ.