### PR TITLE
implement 'string::from(bytes, inlen)'

### DIFF
--- a/modules/string/src/lib.zz
+++ b/modules/string/src/lib.zz
@@ -76,6 +76,17 @@ export fn make(String+tail mut new* self)
     clear(self)
 }
 
+/// make a string from raw bytes with given len
+export fn from(String+t new mut* self, u8* bytes, usize mut inlen)
+    @solver("yices2")
+    where len(bytes) >= inlen
+    model self->len < t
+    model nullterm(self->mem)
+{
+  make(self);
+  self->append_bytes(bytes, inlen);
+}
+
 /// clear the string
 export fn clear(String+tail mut new* self)
     model self->len  == 0

--- a/modules/string/tests/from.zz
+++ b/modules/string/tests/from.zz
@@ -1,0 +1,28 @@
+using string;
+using <stdio.h>::{printf, stdin};
+using <stdlib.h>::{free};
+inline using "native.h"::{getline};
+
+
+test from{
+    stdin  = "hello world\n"
+    stdout = "hello world\n"
+}
+
+export fn main() -> int {
+  char mut * mut line = 0;
+  usize mut l = 0;
+  int nread = as<int>(getline(&line, &l, stdin));
+  if nread < 1 {
+    free(line);
+  } else {
+    static_attest(safe(line));
+    static_attest(nullterm(line));
+    static_attest(len(line) == (usize) nread);
+    new+50 mut s = string::from((u8 *) line, (usize) nread);
+    free(line);
+    printf("%.*s", s.len, s.mem);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This PR implements a constructor function `string::from()` for a `String+` type making it easy to create a new string from bytes and size. This is similar to [`slice::mut_slice::make()`](https://github.com/zetzit/zz/blob/master/modules/slice/src/mut_slice.zz#L24).