### PR TITLE
implement 'string::from_cstr()'

### DIFF
--- a/modules/string/src/lib.zz
+++ b/modules/string/src/lib.zz
@@ -103,6 +103,17 @@ export fn from_slice(String+t new mut* self, Slice *slice)
   self->append_bytes(bytes, size);
 }
 
+/// make a string from a c string
+export fn from_cstr(String+t new mut* self, char *cstr)
+    @solver("yices2")
+    where nullterm(cstr)
+    model nullterm(self->mem)
+    model self->len < t
+{
+  make(self);
+  self->append_cstr(cstr);
+}
+
 /// clear the string
 export fn clear(String+tail mut new* self)
     model self->len  == 0

--- a/modules/string/tests/from.zz
+++ b/modules/string/tests/from.zz
@@ -6,7 +6,7 @@ inline using "native.h"::{getline};
 
 test from{
     stdin  = "hello world\n"
-    stdout = "hello world\nhello world\n"
+    stdout = "hello world\nhello world\nhello world\n"
 }
 
 export fn main() -> int {
@@ -22,9 +22,11 @@ export fn main() -> int {
     new+50 mut s = string::from((u8 *) line, (usize) nread);
     let slice = s.slice();
     new+50 mut copy = string::from_slice(&slice);
+    new+50 mut cstr_copy = string::from_cstr(copy.cstr());
     free(line);
     printf("%.*s", s.len, s.mem);
     printf("%.*s", copy.len, copy.mem);
+    printf("%.*s", cstr_copy.len, cstr_copy.mem);
   }
 
   return 0;


### PR DESCRIPTION
This PR implements `string::from_cstr()` which should make creating `String+` instances much easier 