### PR TITLE
support 'ast::Expression::Name' for macros

### DIFF
--- a/modules/ast/src/lib.zz
+++ b/modules/ast/src/lib.zz
@@ -34,6 +34,67 @@ fn parse_v(err::Err+et mut *e, json::Parser+pt mut* p, void mut * user, char *k,
         }
     }
 }
+
+fn parse_t(err::Err+et mut *e, json::Parser+pt mut* p, void mut * user, char *k, json::Value v)
+    where err::checked(*e)
+    where nullterm(k)
+{
+    let arg = (ExpressionS mut*)user;
+
+    if string::cstr_eq(k, "t") {
+        switch v.t {
+            json::ValueType::Object => {
+              json::next(p,  e, parse_t_other, (void mut*)arg);
+              if err::check(e) {
+                return;
+              }
+            }
+            default => {
+            }
+        }
+    }
+}
+
+fn parse_t_other(err::Err+et mut *e, json::Parser+pt mut* p, void mut * user, char *k, json::Value v)
+    where err::checked(*e)
+    where nullterm(k)
+{
+    let arg = (ExpressionS mut*)user;
+
+    if string::cstr_eq(k, "Other") {
+        switch v.t {
+            json::ValueType::Array => {
+              json::next(p,  e, parse_t_other_value, (void mut*)arg);
+              if err::check(e) {
+                return;
+              }
+            }
+            default => {
+            }
+        }
+    }
+}
+
+fn parse_t_other_value(err::Err+et mut *e, json::Parser+pt mut* p, void mut * user, char *k, json::Value v)
+    where err::checked(*e)
+    where nullterm(k)
+{
+  let arg = (ExpressionS mut*)user;
+
+  switch v.t {
+    json::ValueType::String => {
+      static_attest(safe(arg->pool));
+      static_attest(safe(v.string));
+      static_attest(nullterm(v.string));
+      char mut * dup = arg->pool->malloc(string::strlen(v.string));
+      memcpy(dup, v.string, string::strlen(v.string) + 1);
+      arg->v.string = dup;
+    }
+    default => {
+    }
+  }
+}
+
 fn parse_arg(err::Err+et mut *e, json::Parser+pt mut* p, void mut*user, char *k, json::Value v)
     where err::checked(*e)
     where nullterm(k)
@@ -51,6 +112,12 @@ fn parse_arg(err::Err+et mut *e, json::Parser+pt mut* p, void mut*user, char *k,
             } else if string::cstr_eq(k, "LiteralString") {
                 arg->t = Expression::LiteralString;
                 json::next(p,  e, parse_v, (void mut*)arg);
+                if err::check(e) {
+                    return;
+                }
+            } else if string::cstr_eq(k, "Name") {
+                arg->t = Expression::Name;
+                json::next(p,  e, parse_t, (void mut*)arg);
                 if err::check(e) {
                     return;
                 }
@@ -120,6 +187,7 @@ export enum Expression
     Invalid,
     Literal,
     LiteralString,
+    Name,
 }
 
 export union ExpressionValue {

--- a/tests/mustpass/macro_expr/src/main.zz
+++ b/tests/mustpass/macro_expr/src/main.zz
@@ -7,7 +7,6 @@ using bam;
 
 /// creates literal string with arg0 repeated arg1 times
 export macro repeat()  {
-
     new+1000 a = ast::from_macro();
     err::assert2(a.args[0].t == ast::Expression::LiteralString, "expected arg0: string");
     err::assert2(a.args[1].t == ast::Expression::Literal,       "expected arg1: number");
@@ -32,9 +31,33 @@ export macro make_int() {
     printf("return a;\n");
 }
 
+export macro increment() {
+    new+1000 a = ast::from_macro();
+    if a.args[0].t == ast::Expression::Name {
+        printf("%s = %s + 1;\n", a.args[0].v.string, a.args[0].v.string);
+    }
+}
+
+export macro add() {
+    new+1000 a = ast::from_macro();
+    if a.args[0].t == ast::Expression::Name {
+        printf("%s = %s + %s;\n", a.args[0].v.string, a.args[1].v.string, a.args[2].v.string);
+    }
+}
+
 export fn main() -> int {
 
     @bam::happyness();
+
+    int mut foo = 0;
+    @increment(foo);
+    if 1 != foo {
+      return 1;
+    }
+    @add(foo, 1, 2);
+    if 3 != foo {
+      return 1;
+    }
 
     printf("hello %s\n", @repeat("world ", 32));
     @make_int("a", 1);


### PR DESCRIPTION
This would allow for the use of `ast::Expression::Name` types in a macro expression. One use case I can imagine is a `@format()` macro to support things like:

```c++
int a = 1;
int b = 2;
@format("let sum = {1} + {1} + {2} + {2} + {3}", a, b, 123);
```

An advanced case could be something similar to rust's `std::fmt::Display` trait where the `@format()` macro could make a call to a `display()` function based on tokens in the format string, similar to `format!()` in rust