### PR TITLE
introducing compiler flags as language item

### DIFF
--- a/src/abs.rs
+++ b/src/abs.rs
@@ -1014,7 +1014,10 @@ pub fn abs(
                 for callassert in callassert {
                     abs_expr(callassert, &scope, true, all_modules, &md.name);
                 }
-                for (_,_,block) in &mut body.branches {
+                for (_,expr,block) in &mut body.branches {
+                    if let Some(expr) = expr {
+                        abs_expr(expr, &scope, false, all_modules, &md.name);
+                    }
                     abs_block(block, &scope, all_modules, &md.name);
                 }
                 scope.pop();
@@ -1089,6 +1092,14 @@ pub fn abs(
             ast::Def::Enum { .. } => {}
             ast::Def::Macro { body, .. } => {
                 abs_block(body, &scope, all_modules, &md.name);
+            }
+            ast::Def::Flags { body, .. } => {
+                for (_,expr,block) in &mut body.branches {
+                    if let Some(expr) = expr {
+                        abs_expr(expr, &scope, false, all_modules, &md.name);
+                    }
+                    abs_block(block, &scope, all_modules, &md.name);
+                }
             }
             ast::Def::Testcase { fields, .. } => {
                 for (_, expr) in fields {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -148,6 +148,9 @@ pub enum Def {
         args: Vec<String>,
         body: Block,
     },
+    Flags {
+        body: ConditionalBlock,
+    },
     Testcase {
         fields: Vec<(String, Expression)>,
     },

--- a/src/emitter_docs.rs
+++ b/src/emitter_docs.rs
@@ -94,6 +94,7 @@ impl Emitter {
             }
 
             match d.def {
+                ast::Def::Flags { .. } => {}
                 ast::Def::Macro { .. } => {}
                 ast::Def::Const { .. } => self.emit_const(&d),
                 ast::Def::Static { .. } => self.emit_static(&d),

--- a/src/emitter_js.rs
+++ b/src/emitter_js.rs
@@ -536,6 +536,7 @@ impl Emitter {
 
             self.emit_loc(&d.loc);
             match d.def {
+                ast::Def::Flags { .. } => {}
                 ast::Def::Macro { .. } => {}
                 ast::Def::Const { .. } => self.emit_const(&d),
                 ast::Def::Static { .. } => self.emit_static(&d),

--- a/src/emitter_py.rs
+++ b/src/emitter_py.rs
@@ -281,6 +281,7 @@ static inline void * pyFATGetPtr(PyObject * obj , char * expected_type) {{
 
             self.emit_loc(&d.loc);
             match d.def {
+                ast::Def::Flags { .. } => {}
                 ast::Def::Macro { .. } => {}
                 ast::Def::Const { .. } => self.emit_const(&d),
                 ast::Def::Static { .. } => self.emit_static(&d),

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -340,6 +340,8 @@ pub fn expand(module: &mut flatten::Module) -> Result<(), Error> {
                 }
                 */
             }
+            ast::Def::Flags { .. } => {
+            }
             ast::Def::Macro { .. } => {
                 stack.alloc(
                     Name::from(&d.name),

--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -584,6 +584,15 @@ pub fn flatten(md: &ast::Module, all_modules: &HashMap<Name, loader::Module>, ex
                     decl_deps.extend(block_deps(cr, body));
                     forceinline.insert(name.clone());
                 }
+                ast::Def::Flags { body, .. } => {
+                    for (_, branch_expr, body) in &body.branches {
+                        if let Some(expr) = branch_expr {
+                            impl_deps.extend(expr_deps(cr, expr));
+                        }
+                        impl_deps.extend(block_deps(cr, body));
+                    }
+                    forceinline.insert(name.clone());
+                }
                 ast::Def::Testcase { fields, .. } => {
                     for (_, expr) in fields {
                         decl_deps.extend(expr_deps(cr, expr));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,18 +81,12 @@ pub fn build(buildset: BuildSet, variant: &str, stage: make::Stage, _slow: bool)
     ]);
 
     let mut modules = HashMap::new();
-    let features = project
-        .features(variant)
-        .into_iter()
-        .map(|(n, (e, _))| (n, e))
-        .collect();
     if root.join("src").exists() {
         loader::load(
             &mut modules,
             &project.project,
             &project_name,
             &root.join("src"),
-            &features,
             &stage,
         );
     }
@@ -102,7 +96,6 @@ pub fn build(buildset: BuildSet, variant: &str, stage: make::Stage, _slow: bool)
             &project.project,
             &project_tests_name,
             &root.join("tests").canonicalize().unwrap(),
-            &features,
             &stage,
         );
     }
@@ -197,17 +190,11 @@ fn getdep(
     let (root, project) = project::load(&found);
     let project_name = Name(vec![String::new(), project.project.name.clone()]);
     if found.join("src").exists() {
-        let features = project
-            .features("default")
-            .into_iter()
-            .map(|(n, (e, _))| (n, e))
-            .collect();
         loader::load(
             modules,
             &project.project,
             &project_name,
             &found.join("src"),
-            &features,
             &stage,
         );
     }
@@ -238,7 +225,6 @@ fn getdep(
         rootproj.pkgconfig.push(i.to_string_lossy().into());
     }
     rootproj.cflags.extend(project.project.cflags);
-    rootproj.lflags.extend(project.project.lflags);
 
     if let Some(deps) = &project.dependencies {
         for (name, dep) in deps {

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -22,7 +22,6 @@ pub fn load(
     project: &super::project::Project,
     artifact_name: &Name,
     src: &Path,
-    features: &HashMap<String, bool>,
     stage: &Stage,
 ) {
     let mut files = Vec::new();
@@ -93,7 +92,7 @@ pub fn load(
             if !silent {
                 pb.lock().unwrap().message(&format!("parsing {:?} ", path));
             }
-            let mut m = parser::parse(&path, features, stage);
+            let mut m = parser::parse(&path, stage);
             m.name = module_name;
 
             debug!("loaded {:?} as {}", path, m.name);

--- a/src/make.rs
+++ b/src/make.rs
@@ -129,8 +129,6 @@ pub struct Make {
 
 impl Make {
     pub fn new(mut config: Config, variant: &str, stage: Stage, artifact: Artifact) -> Self {
-        let features = config.features(variant);
-
         let mut cflags: Vec<String> =
             match std::env::var("TARGET_CFLAGS").or(std::env::var("CFLAGS")) {
                 Err(_) => Vec::new(),
@@ -170,22 +168,10 @@ impl Make {
             cxx = "afl-clang++".to_string();
         }
 
-        let mut cincludes = config.project.cincludes.clone();
-        let mut pkgconfig = config.project.pkgconfig.clone();
-        let mut cobjects = std::mem::replace(&mut config.project.cobjects, Vec::new());
-        let mut user_cflags = config.project.cflags.clone();
-        let mut user_lflags = config.project.lflags.clone();
-
-        for (_, (enabled, feature)) in &features {
-            if !enabled {
-                continue;
-            }
-            cincludes.extend(feature.cincludes.clone());
-            pkgconfig.extend(feature.pkgconfig.clone());
-            cobjects.extend(feature.cobjects.clone());
-            user_cflags.extend(feature.cflags.clone());
-            user_lflags.extend(feature.lflags.clone());
-        }
+        let cincludes = config.project.cincludes.clone();
+        let pkgconfig = config.project.pkgconfig.clone();
+        let cobjects = std::mem::replace(&mut config.project.cobjects, Vec::new());
+        let user_cflags = config.project.cflags.clone();
 
         for cinc in &cincludes {
             cflags.push("-I".into());
@@ -223,7 +209,6 @@ impl Make {
         cflags.push("-fvisibility=hidden".to_string());
 
         cflags.extend(user_cflags);
-        lflags.extend(user_lflags);
 
         let mut stage = stage.clone();
         if let Ok(_) = std::env::var("ZZ_BUILD_NO_PIC") {

--- a/src/makro.rs
+++ b/src/makro.rs
@@ -138,7 +138,7 @@ pub fn stm(
             None => break,
             Some(v) => v,
         };
-        for stm2 in parser::parse_block(&path, &HashMap::new(), &super::make::Stage::release(), pp)
+        for stm2 in parser::parse_block(&path, &super::make::Stage::release(), pp)
             .statements
         {
             statements.push(stm2);

--- a/src/symbolic.rs
+++ b/src/symbolic.rs
@@ -588,6 +588,8 @@ impl Symbolic {
                         value += 1;
                     }
                 }
+                ast::Def::Flags { .. } => {
+                }
                 ast::Def::Macro { .. } => {
                     let sym = self.alloc(
                         Name::from(&d.name),

--- a/src/zz.pest
+++ b/src/zz.pest
@@ -158,6 +158,9 @@ imacro          = { ( exported | key_shared)? ~ "macro" ~ ident ~ "(" ~ macro_ar
 gblock = { block | (if_stm | elseif_stm | else_stm )+ }
 
 
+flags  = {"flags" ~ gblock}
+
+
 // statements
 
 infix = _{
@@ -318,6 +321,7 @@ file        = { SOI ~ (struct_d
                         | theory
                         | ienum
                         | symbol
+                        | flags
                         | import
                         | constant
                         | testcase


### PR DESCRIPTION
use like this:

    flags {
        linker("-lbla")
    }

works with conditionals:

    flags if #(os::_WIN32){
        linker("-lW32_bla")
    }

eventually macro support will allow generating these from configure tests,
something like:

    flags {
      @pkgconfig("gtk")
    }

in order to integrate into C conditionals they are emitted as pragma.
but there's really only msvc that supports linker pragmas,
so make also parses them back out of the c file and appends them to the
compiler commandline.

this means export to other build systems becomes slightly inconsistent,
but it would have been that way anyway, because every build system works
differently.

- make: we can just prepend a -E phase to each compile unit,
- python and nodejs: same as script.
- rust: same as buildscript
- golang: would have never worked anyway. best shot is emit each variant
  as different golang file?
- cmake: no idea. cmake is complicated