### PR TITLE
semi-amalgam cobjects

### DIFF
--- a/src/emitter_go.rs
+++ b/src/emitter_go.rs
@@ -3,6 +3,7 @@
 use super::ast;
 use super::flatten;
 use super::make;
+use super::emitter_common;
 use super::name::Name;
 use super::parser::{self, emit_error};
 use super::project::Project;
@@ -31,19 +32,15 @@ pub fn make_module(make: &super::make::Make) {
     for step in &make.steps {
         let s = step.source.parent().unwrap();
         if s.file_name().unwrap() == "zz" || s.file_name().unwrap() == "gen"{
-            let s = s
-                .parent()
-                .unwrap()
-                .join("js")
-                .join(step.source.file_name().unwrap());
-
             let c = fs::read_to_string(&step.source).unwrap();
             f.write(c.as_bytes());
         } else {
-            let f = step.source.to_string_lossy().replace("/", "_");
+            let ie = emitter_common::path_rel(&pdir, &step.source);
+
+            let f = ie.to_string_lossy().replace("/", "_").replace("..", "_");
             let p = pdir.join(f);
             let mut f = fs::File::create(&p).expect(&format!("cannot create {:?}", p));
-            write!(f, "#include \"../../../{}\"\n", step.source.to_string_lossy()).unwrap();
+            write!(f, "#include {:?}", ie);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod project;
 pub mod repos;
 pub mod smt;
 pub mod symbolic;
+pub mod mergecc;
 
 use name::Name;
 use std::collections::HashMap;
@@ -67,9 +68,11 @@ pub fn build(buildset: BuildSet, variant: &str, stage: make::Stage, _slow: bool)
     let td = project::target_dir();
     std::fs::create_dir_all(td.join(stage.to_string()).join("c"))
         .expect("create target dir");
-    std::fs::create_dir_all(td.join(stage.to_string()).join("gen"))
-        .expect("create target dir");
     std::fs::create_dir_all(td.join(stage.to_string()).join("zz"))
+        .expect("create target dir");
+    std::fs::create_dir_all(td.join("gen"))
+        .expect("create target dir");
+    std::fs::create_dir_all(td.join("c"))
         .expect("create target dir");
     std::fs::create_dir_all(td.join("include").join("zz"))
         .expect("create target dir");

--- a/src/mergecc.rs
+++ b/src/mergecc.rs
@@ -1,0 +1,96 @@
+use std::path::Path;
+use std::path::PathBuf;
+use std::fs;
+use std::io::{self, BufRead, Write};
+use std::collections::HashMap;
+
+
+#[derive(Default)]
+struct M {
+    outbase:        PathBuf,
+    includes:       Vec<String>,
+    visited:        HashMap<PathBuf, PathBuf>,
+}
+
+pub fn mergecc(includes: &Vec<String>, outbase: &Path, inp: &Path) -> PathBuf {
+
+    let mut m = M {
+        includes:   includes.clone(),
+        outbase:    outbase.into(),
+        ..Default::default()
+    };
+
+    m.copy(inp.into())
+}
+
+
+impl M {
+
+fn copy(&mut self, inp: PathBuf) -> PathBuf
+{
+    if let Some(x) = self.visited.get(&inp) {
+        return x.clone();
+    }
+
+    let oext = inp.extension().map(|v| v.to_str().unwrap()).unwrap_or("");
+
+    let merged = inp.to_string_lossy()
+        .replace(|c: char| !c.is_alphanumeric(), "_");
+    let merged = self.outbase.join(merged + "." + oext);
+
+    self.visited.insert(inp.clone(), merged.clone());
+
+    if let Ok(target) = std::fs::metadata(&merged) {
+        if let Ok(source) = std::fs::metadata(&inp) {
+            let itarget = target.modified().expect(&format!("cannot stat {:?}", target));
+            let isource = source.modified().expect(&format!("cannot stat {:?}", source));
+            if itarget > isource {
+                return merged;
+            }
+        }
+    }
+
+    let mut w = fs::File::create(&merged).expect(&format!("cannot create {:?}", merged));
+
+    let iff = fs::File::open(&inp).expect(&format!("cannot open {:?}", inp));
+
+    'outer: for line in io::BufReader::new(iff).lines() {
+        let line = line.unwrap();
+
+        if line.starts_with("#include ") {
+            let l : Vec<&str> = line.split(" ").collect();
+            if l.len() > 1 {
+                let mut l = l[1].trim().to_string();
+                if l.starts_with("\"") && l.ends_with("\"") {
+                    l.remove(0);
+                    l.remove(l.len() - 1);
+
+                    if let Some(p) = inp.parent() {
+                        let l = p.join(&l);
+                        if l.exists() {
+                            let nu = self.copy(l);
+                            let nu = nu.file_name().unwrap();
+                            w.write(format!("#include {:?}\n", nu).as_bytes()).unwrap();
+                            continue 'outer;
+                        }
+                    }
+                    for include in &self.includes {
+                        let l = Path::new(include).join(&l);
+                        if l.exists() {
+                            let nu = self.copy(l);
+                            let nu = nu.file_name().unwrap();
+                            w.write(format!("#include {:?}\n", nu).as_bytes()).unwrap();
+                            continue 'outer;
+                        }
+                    }
+                }
+            }
+        }
+
+        w.write(line.as_bytes()).unwrap();
+        w.write(b"\n").unwrap();
+    }
+
+    return merged;
+}
+}

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -232,6 +232,8 @@ impl Pipeline {
                 let mut module = self.modules.get(&name).unwrap().clone();
                 match &mut module {
                     loader::Module::C(c) => {
+                        //TODO Module::C is actually a header?
+
                         self.pb_done("comp", hn);
                         Some((
                             name.clone(),


### PR DESCRIPTION
external C objects with include paths are unsupported by golang.
that's why this change parses all includes and moves everything
relative to a single directory.

this is good enough for me, but may need improvement for other use
cases, for example we can't emit a true amalgam (yet?!),
because that would require parsing all the ifdefs.
Its unclear if thats even possible without resolving the
system specific ones like #if _WIN32
