### PR TITLE
allow tail of to void*

### DIFF
--- a/tests/mustpass/tail_of_void/.gitignore
+++ b/tests/mustpass/tail_of_void/.gitignore
@@ -1,0 +1,6 @@
+/target
+.gdb_history
+vgcore.*
+**/*.o
+**/*.parsecache
+**/*.buildcache

--- a/tests/mustpass/tail_of_void/src/main.zz
+++ b/tests/mustpass/tail_of_void/src/main.zz
@@ -1,0 +1,46 @@
+using log;
+using slice;
+using err;
+
+fn dump(void+vt * obj, usize expect) {
+    log::info("dumping object of size %d", vt);
+
+    err::assert(expect == vt);
+}
+
+struct A {
+    u16  x;
+    u16  y;
+};
+
+
+struct X+ {
+    u32 forp;
+    u32 dummy;
+    u32 x[];
+};
+
+fn ftail(X+xt * obj) {
+    dump(obj, 108);
+}
+
+export fn main() -> int {
+
+    A a;
+
+    dump(&a, 4);
+    dump(&A{x:1}, 4);
+
+    A *b = &a;
+    dump(b, 4);
+
+
+    dump("literal string", 14);
+
+
+    X+100 x;
+    ftail(&x);
+    dump(&x, 108);
+
+    return 0;
+}

--- a/tests/mustpass/tail_of_void/zz.toml
+++ b/tests/mustpass/tail_of_void/zz.toml
@@ -1,0 +1,14 @@
+[project]
+version = "0.1.0"
+name = "tail_of_void"
+cincludes = []
+cobjects = []
+pkgconfig = []
+cflags = []
+
+[dependencies]
+mem = "1"
+log = "1"
+err = "1"
+
+[repos]


### PR DESCRIPTION
this enables building functions that take "any object and its size",
specifically memory pools for generic containers.

Since we do not allow template functions, this is getting us closer to
generic functions

i'd imagine something like

```
struct List+ {
    pool:Pool+ pool;
}

fn append(List+lt * self, void+vt * item)
{
    void *store = self->pool.alloc(vt);
    mem::cpy(item, store, vt);
}

```