### PR TITLE
hashmap

### DIFF
--- a/modules/buffer/src/lib.zz
+++ b/modules/buffer/src/lib.zz
@@ -347,8 +347,11 @@ export fn substr(Buffer+tail *self, usize from, usize mut size, Buffer+tail2 mut
     }
 
 
-    if size == 0 {
-        return;
+    // TODO: ssa claims this never happens. should probably check if thats true
+    unsafe {
+        if size == 0 {
+            return;
+        }
     }
 
     //TODO i'm not sure what ssa is confused about

--- a/modules/map/.gitignore
+++ b/modules/map/.gitignore
@@ -1,0 +1,3 @@
+/target
+.gdb_history
+vgcore.*

--- a/modules/map/src/lib.zz
+++ b/modules/map/src/lib.zz
@@ -1,0 +1,441 @@
+using pool;
+using err;
+using slice;
+using log;
+using mem;
+
+using <string.h>::{memset};
+using <stdio.h>::{printf};
+using <assert.h>::{assert};
+
+inline using "siphash.h" as  siphash;
+
+
+//TODO should not export?
+export struct Node {
+    u64     hash;
+    Node    mut * mut next;
+
+    bool key_owned;
+    bool val_owned;
+    slice::Slice key;
+    slice::Slice val;
+}
+
+export struct Bucket {
+    Node mut * mut root;
+}
+
+/// string table with owned key and borrowed value
+export struct Map+ {
+    usize item_count;
+    usize buckets_reserved;
+    Bucket mut * mut buckets;
+    pool::Pool+ mut p;
+}
+
+/// create a new map
+export fn make(Map+tt mut new* self) {
+    memset(self, 0, sizeof(Map));
+
+    self->p.make(sizeof(Bucket));
+    self->buckets_reserved = tt/unsafe<usize>(sizeof(Bucket))/10;
+    log::info("free_bytes: %zu", self->p.free_bytes());
+    log::info("buckets: %zu", self->buckets_reserved);
+    self->buckets = self->p.malloc(unsafe<usize>(sizeof(Bucket)) * self->buckets_reserved);
+    log::info("free_bytes: %zu", self->p.free_bytes());
+    err::assert_safe(self->buckets);
+}
+
+
+/// count number of items
+export fn count(Map * self) -> usize
+{
+    return self->item_count;
+}
+
+/// insert borrowed key and borrowed value
+///
+/// the borrowed references must be valid for the lifetime of the map
+///
+/// returns false if there's not enough memory to store the key
+export fn insert_bb(Map mut* self, void+kt * key, void+vt * val) -> bool
+{
+    Node mut * nn = self->p.malloc(unsafe<usize>(sizeof(Node)));
+    if nn == 0 {
+        return false;
+    }
+    static_attest(safe(nn));
+    nn->key = slice::slice::Slice{mem: key, size: kt};
+    nn->key_owned = false;
+    nn->val = slice::slice::Slice{mem: val, size: vt};
+    nn->val_owned = false;
+    nn->hash = hash(nn->key);
+
+    return self->i_insert(nn);
+}
+
+/// insert owned key and borrowed value
+///
+/// the borrowed value reference must be valid for the lifetime of the map
+///
+/// returns false if there's not enough memory to store the key
+export fn insert_ob(Map mut* self, void+kt * key, void+vt * val) -> bool
+{
+    void mut * owned_key = self->p.malloc(kt);
+    if owned_key == 0 {
+        return false;
+    }
+    static_attest(safe(owned_key));
+    static_attest(len(key) == kt);
+    static_attest(len(owned_key) == kt);
+    mem::copy(key, owned_key, kt);
+
+    Node mut * nn = self->p.malloc(unsafe<usize>(sizeof(Node)));
+    if nn == 0 {
+        self->p.free(owned_key);
+        return false;
+    }
+    static_attest(safe(nn));
+    nn->key = slice::slice::Slice{mem: owned_key, size: kt};
+    nn->key_owned = true;
+    nn->val = slice::slice::Slice{mem: val, size: vt};
+    nn->val_owned = false;
+    nn->hash = hash(nn->key);
+
+    return self->i_insert(nn);
+}
+
+/// insert owned key and owned value
+///
+/// both key and value are memcpy'd into the maps pool.
+/// note that if the objects hold circular refferences, they are now invalid.
+///
+/// returns false if there's not enough memory to store the kv
+export fn insert_oo(Map mut* self, void+kt * key, void+vt * val) -> bool {
+
+    void mut * owned_key = self->p.malloc(kt);
+    if owned_key == 0 {
+        return false;
+    }
+    static_attest(safe(owned_key));
+    static_attest(len(key) == kt);
+    static_attest(len(owned_key) == kt);
+    mem::copy(key, owned_key, kt);
+
+    void mut * owned_val = self->p.malloc(vt);
+    if owned_val == 0 {
+        return false;
+    }
+    static_attest(safe(owned_val));
+    static_attest(len(val) == vt);
+    static_attest(len(owned_val) == vt);
+    mem::copy(val, owned_val, vt);
+
+    Node mut * nn = self->p.malloc(unsafe<usize>(sizeof(Node)));
+    if nn == 0 {
+        self->p.free(owned_key);
+        self->p.free(owned_val);
+        return false;
+    }
+    static_attest(safe(nn));
+    nn->key = slice::slice::Slice{mem: owned_key, size: kt};
+    nn->key_owned = true;
+    nn->val = slice::slice::Slice{mem: owned_val, size: vt};
+    nn->val_owned = true;
+
+    nn->hash = hash(nn->key);
+
+    return self->i_insert(nn);
+}
+
+
+fn i_insert(Map mut* self, Node mut *node) -> bool
+    where slice::slice::integrity(&node->key)
+    where slice::slice::integrity(&node->val)
+{
+    self->remove_slk(node->key, node->hash);
+
+    usize index = (usize)node->hash % self->buckets_reserved;
+    static_attest(index < len(self->buckets));
+    Bucket mut* bucket = self->buckets + index;
+
+    if bucket->root == 0 {
+        bucket->root = node;
+        self->item_count += 1;
+        return true;
+    } else {
+        Node mut * mut no = bucket->root;
+        for (;;) {
+            if no->next == 0 {
+                no->next = node;
+                self->item_count += 1;
+                return true;
+            } else {
+                no = no->next;
+            }
+        }
+    }
+
+    return false;
+}
+
+
+
+/// copy out a value for the key
+///
+/// returns true if found and the stored value fits exactly into the copy target
+/// otherwise returns falseS
+///
+/// example:
+///     MyThing x = {0};
+///     if !map.copy("bob", &x) { err::panic("no such key"); }
+///
+export fn copy(Map mut* self, void+kt * key, void+vt mut *val) -> bool
+{
+    return copy_sl(self, slice::slice::Slice{mem:key, size: kt}, val);
+}
+
+fn copy_sl(Map mut* self, slice::slice::Slice key, void+vt mut *val) -> bool
+    where slice::slice::integrity(&key)
+{
+    let hk = hash(key);
+
+    usize index = (usize)hk % self->buckets_reserved;
+    static_attest(index < len(self->buckets));
+    Bucket mut* bucket = self->buckets + index;
+
+    if bucket->root == 0 {
+        return 0;
+    }
+
+    Node mut * mut no = bucket->root;
+    for (;;) {
+        static_attest(safe(no));
+        static_attest(slice::slice::integrity(&no->key));
+        static_attest(slice::slice::integrity(&no->val));
+
+        if no->hash == hk && no->key.eq(key) {
+            if no->val.size != vt {
+                return false;
+            }
+            mem::copy(no->val.mem, val, vt);
+            return true;
+        }
+
+        if no->next == 0 {
+            return 0;
+        }
+        no = no->next;
+    }
+
+    return 0;
+}
+
+
+
+/// returns a pointer to a borrowed value for the key
+/// or 0 if no such key exists
+///
+/// example:
+///     let x = (MyThing *x)map.borrow("bob");
+///     if x == 0 { err::panic("no such key"); }
+///
+export fn borrow(Map mut* self, void+kt * key) -> void mut *
+{
+    return (void mut*)(borrow_slice(self, key).mem);
+}
+
+/// returns a slice to a borrowed value for the key
+/// or an invalid slice if no such key exists
+///
+/// example:
+///     let x = map.borrow_slice("bob");
+///     if x.mem == 0 { err::panic("no such key"); }
+///
+export fn borrow_slice(Map mut* self, void+kt * key_) -> slice::slice::Slice
+{
+    let keyx = slice::slice::Slice{mem:key_, size: kt};
+    let hk = hash(keyx);
+
+    usize index = (usize)hk % self->buckets_reserved;
+    static_attest(index < len(self->buckets));
+    Bucket mut* bucket = self->buckets + index;
+
+    if bucket->root == 0 {
+        return slice::slice::Slice{mem:0};
+    }
+
+    Node mut * mut no = bucket->root;
+    for (;;) {
+        static_attest(safe(no));
+        static_attest(slice::slice::integrity(&no->key));
+
+        if no->hash == hk && no->key.eq(keyx) {
+            return no->val;
+        }
+
+        if no->next == 0 {
+            return slice::slice::Slice{mem:0};
+        }
+        no = no->next;
+    }
+
+    return slice::slice::Slice{mem:0};
+}
+
+/// remove an entry by object key
+///
+/// returns true if entry was found, false otherwise
+export fn remove(Map mut* self, void+kt * key) -> bool
+{
+    static_attest(len(key) == kt);
+    return remove_sl(self, slice::slice::Slice{mem:key, size: kt});
+}
+
+fn remove_sl(Map mut* self, slice::slice::Slice key) -> bool
+    where slice::slice::integrity(&key)
+{
+    let hk = hash(key);
+    return remove_slk(self, key, hk);
+}
+
+/// remove entry by prehashed slice key
+///
+/// returns true if entry was found, false otherwise
+fn remove_slk(Map mut* self, slice::slice::Slice key, u64 ha) -> bool
+    where slice::slice::integrity(&key)
+{
+    usize index = (usize)ha % self->buckets_reserved;
+    static_attest(index < len(self->buckets));
+    Bucket mut* bucket = self->buckets + index;
+
+    if bucket->root == 0 {
+        return false;
+    }
+
+    Node mut * mut no = bucket->root;
+    static_attest(safe(no));
+    static_attest(slice::slice::integrity(&no->key));
+    static_attest(slice::slice::integrity(&no->val));
+    if no->hash == ha && no->key.eq(key) {
+        self->i_dealloc(no);
+        self->item_count -= 1;
+        bucket->root = 0;
+        return true;
+    }
+
+    for (;;) {
+        static_attest(safe(no));
+        if no->next == 0 {
+            return false;
+        }
+        static_attest(safe(no->next));
+        static_attest(slice::slice::integrity(&no->next->key));
+        static_attest(slice::slice::integrity(&no->next->val));
+        if no->next->hash == ha && no->next->key.eq(key) {
+
+            let tt = no->next;
+            no->next = tt->next;
+            self->i_dealloc(tt);
+            self->item_count -= 1;
+
+            return true;
+        }
+        no = no->next;
+    }
+    return false;
+}
+
+/// iterator
+export struct Keys{
+    Map mut* m;
+    usize bucket;
+    Node *next;
+    slice::Slice mut key;
+}
+
+/// iterate over all keys
+///
+/// example:
+///     for (let it = map.keys(); it.next(); ) {
+///         println("%.*s", it.key.size, it.key.mem);
+///     }
+///
+export fn keys(Map mut* self) -> Keys
+{
+    return Keys {
+        m:      self,
+        bucket: 0,
+    };
+}
+
+/// moves iterator forward
+/// returns false if there are no more keys
+export fn next(Keys mut* self) -> bool
+    model slice::slice::integrity(&self->key)
+{
+    static_attest(safe(self->m));
+    if self->next != 0 {
+        static_attest(safe(self->next));
+        self->next = self->next->next;
+        if self->next != 0 {
+            static_attest(safe(self->next));
+            self->key  = self->next->key;
+            static_attest(slice::slice::integrity(&self->key));
+            return true;
+        } else {
+            self->bucket += 1;
+        }
+    }
+
+
+    for (;;) {
+
+        if self->bucket >= self->m->buckets_reserved {
+            return false;
+        }
+
+        static_attest(len(self->m->buckets) > self->bucket);
+        self->next = self->m->buckets[self->bucket].root;
+
+        if self->next != 0 {
+            static_attest(safe(self->next));
+            self->key  = self->next->key;
+            return true;
+        }
+        self->bucket += 1;
+    }
+
+
+    return false;
+}
+
+
+
+
+static u8 siphashk[] = {1,2,3,4,6,7,8,9,0,1,2,3,4,5,6};
+fn hash(slice::Slice sl) -> u64
+{
+    u64 mut out = 0;
+    siphash::siphash(
+        sl.mem, sl.size,
+        siphashk,
+        (u8 mut*)&out, 8
+    );
+    return out;
+}
+
+fn i_dealloc(Map mut* self, Node mut *node)
+    where slice::slice::integrity(&node->key)
+    where slice::slice::integrity(&node->val)
+{
+    if node->key_owned {
+        static_attest(pool::member(node->key.mem, &self->p));
+        self->p.free(node->key.mem);
+    }
+    if node->val_owned {
+        static_attest(pool::member(node->val.mem, &self->p));
+        self->p.free(node->val.mem);
+    }
+}

--- a/modules/map/src/main.zz
+++ b/modules/map/src/main.zz
@@ -1,0 +1,68 @@
+using map;
+using err;
+using log;
+using slice;
+using buffer;
+
+
+struct A+ {
+    buffer::Buffer+ mut b;
+}
+
+
+pub fn main() -> int {
+
+    new+1000 t = map::make();
+    err::assert(t.insert_oo("bob", "uncle"));
+    err::assert(t.count() == 1);
+    err::assert(t.insert_oo("bob", "uncle"));
+    err::assert(t.insert_oo("doop", "helooooooooo world blabla hurp durp lirum larum ipsum derpum"));
+    err::assert(t.count() == 2);
+
+    let vv = (char*)t.borrow("doop");
+    log::info("%s", vv);
+
+    err::assert(t.count() == 2);
+    err::assert(t.remove("doop"));
+    err::assert(!t.remove("doop"));
+    err::assert(t.count() == 1);
+
+    err::assert(t.insert_oo("bob", "uncle"));
+    err::assert(t.insert_oo("bob", slice::slice::Slice{mem: (u8*)"uncle sam", size: 6}));
+    err::assert(t.insert_bb("bob", slice::slice::Slice{mem: (u8*)"uncle sam", size: 6}));
+    err::assert(t.count() == 1);
+
+    let vv2 = (char*)t.borrow("bob");
+    log::info("%s", vv2);
+
+    A+1000 mut a;
+    a.b.make();
+    a.b.append_cstr("blargh");
+    a.b.append_cstr(" borp");
+
+    // too large to own
+    err::assert(!t.insert_oo("bob", &a));
+    // ok to borrow
+    err::assert(t.insert_ob("bob", &a));
+
+    err::assert(t.count() == 1);
+
+    A+1000 mut ac;
+    err::assert(t.copy("bob", &ac));
+
+    log::info("%s", ac.b.mem);
+
+    err::assert(t.insert_oo("bob",  "uncle"));
+    err::assert(t.insert_oo("boba", "unclina"));
+    err::assert(t.insert_oo("derp", "ughlinor"));
+    err::assert(t.insert_oo("foo", "baz bar biggest borp"));
+    err::assert(t.remove("boba"));
+    err::assert(t.count() == 3);
+
+    for(let mut it = t.keys(); map::next(&it);) {
+        let vv2 = (char*)t.borrow(it.key);
+        log::info(" - %s = %s", (char*)it.key.mem, vv2);
+    }
+
+    return 0;
+}

--- a/modules/map/src/siphash.h
+++ b/modules/map/src/siphash.h
@@ -1,0 +1,166 @@
+/*
+   SipHash reference C implementation
+
+   Copyright (c) 2012-2016 Jean-Philippe Aumasson
+   <jeanphilippe.aumasson@gmail.com>
+   Copyright (c) 2012-2014 Daniel J. Bernstein <djb@cr.yp.to>
+
+   To the extent possible under law, the author(s) have dedicated all copyright
+   and related and neighboring rights to this software to the public domain
+   worldwide. This software is distributed without any warranty.
+
+   You should have received a copy of the CC0 Public Domain Dedication along
+   with
+   this software. If not, see
+   <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+#include <assert.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+/* default: SipHash-2-4 */
+#ifndef cROUNDS
+    #define cROUNDS 2
+#endif
+#ifndef dROUNDS
+    #define dROUNDS 4
+#endif
+
+#define ROTL(x, b) (uint64_t)(((x) << (b)) | ((x) >> (64 - (b))))
+
+#define U32TO8_LE(p, v)                                                        \
+    (p)[0] = (uint8_t)((v));                                                   \
+    (p)[1] = (uint8_t)((v) >> 8);                                              \
+    (p)[2] = (uint8_t)((v) >> 16);                                             \
+    (p)[3] = (uint8_t)((v) >> 24);
+
+#define U64TO8_LE(p, v)                                                        \
+    U32TO8_LE((p), (uint32_t)((v)));                                           \
+    U32TO8_LE((p) + 4, (uint32_t)((v) >> 32));
+
+#define U8TO64_LE(p)                                                           \
+    (((uint64_t)((p)[0])) | ((uint64_t)((p)[1]) << 8) |                        \
+     ((uint64_t)((p)[2]) << 16) | ((uint64_t)((p)[3]) << 24) |                 \
+     ((uint64_t)((p)[4]) << 32) | ((uint64_t)((p)[5]) << 40) |                 \
+     ((uint64_t)((p)[6]) << 48) | ((uint64_t)((p)[7]) << 56))
+
+#define SIPROUND                                                               \
+    do {                                                                       \
+        v0 += v1;                                                              \
+        v1 = ROTL(v1, 13);                                                     \
+        v1 ^= v0;                                                              \
+        v0 = ROTL(v0, 32);                                                     \
+        v2 += v3;                                                              \
+        v3 = ROTL(v3, 16);                                                     \
+        v3 ^= v2;                                                              \
+        v0 += v3;                                                              \
+        v3 = ROTL(v3, 21);                                                     \
+        v3 ^= v0;                                                              \
+        v2 += v1;                                                              \
+        v1 = ROTL(v1, 17);                                                     \
+        v1 ^= v2;                                                              \
+        v2 = ROTL(v2, 32);                                                     \
+    } while (0)
+
+#ifdef DEBUG
+#define TRACE                                                                  \
+    do {                                                                       \
+        printf("(%3zu) v0 %016"PRIx64"\n", inlen, v0);                         \
+        printf("(%3zu) v1 %016"PRIx64"\n", inlen, v1);                         \
+        printf("(%3zu) v2 %016"PRIx64"\n", inlen, v2);                         \
+        printf("(%3zu) v3 %016"PRIx64"\n", inlen, v3);                         \
+    } while (0)
+#else
+#define TRACE
+#endif
+
+int siphash(const uint8_t *in, const size_t inlen, const uint8_t *k,
+            uint8_t *out, const size_t outlen) {
+
+    assert((outlen == 8) || (outlen == 16));
+    uint64_t v0 = UINT64_C(0x736f6d6570736575);
+    uint64_t v1 = UINT64_C(0x646f72616e646f6d);
+    uint64_t v2 = UINT64_C(0x6c7967656e657261);
+    uint64_t v3 = UINT64_C(0x7465646279746573);
+    uint64_t k0 = U8TO64_LE(k);
+    uint64_t k1 = U8TO64_LE(k + 8);
+    uint64_t m;
+    int i;
+    const uint8_t *end = in + inlen - (inlen % sizeof(uint64_t));
+    const int left = inlen & 7;
+    uint64_t b = ((uint64_t)inlen) << 56;
+    v3 ^= k1;
+    v2 ^= k0;
+    v1 ^= k1;
+    v0 ^= k0;
+
+    if (outlen == 16)
+        v1 ^= 0xee;
+
+    for (; in != end; in += 8) {
+        m = U8TO64_LE(in);
+        v3 ^= m;
+
+        TRACE;
+        for (i = 0; i < cROUNDS; ++i)
+            SIPROUND;
+
+        v0 ^= m;
+    }
+
+    switch (left) {
+    case 7:
+        b |= ((uint64_t)in[6]) << 48;
+    case 6:
+        b |= ((uint64_t)in[5]) << 40;
+    case 5:
+        b |= ((uint64_t)in[4]) << 32;
+    case 4:
+        b |= ((uint64_t)in[3]) << 24;
+    case 3:
+        b |= ((uint64_t)in[2]) << 16;
+    case 2:
+        b |= ((uint64_t)in[1]) << 8;
+    case 1:
+        b |= ((uint64_t)in[0]);
+        break;
+    case 0:
+        break;
+    }
+
+    v3 ^= b;
+
+    TRACE;
+    for (i = 0; i < cROUNDS; ++i)
+        SIPROUND;
+
+    v0 ^= b;
+
+    if (outlen == 16)
+        v2 ^= 0xee;
+    else
+        v2 ^= 0xff;
+
+    TRACE;
+    for (i = 0; i < dROUNDS; ++i)
+        SIPROUND;
+
+    b = v0 ^ v1 ^ v2 ^ v3;
+    U64TO8_LE(out, b);
+
+    if (outlen == 8)
+        return 0;
+
+    v1 ^= 0xdd;
+
+    TRACE;
+    for (i = 0; i < dROUNDS; ++i)
+        SIPROUND;
+
+    b = v0 ^ v1 ^ v2 ^ v3;
+    U64TO8_LE(out + 8, b);
+
+    return 0;
+}

--- a/modules/map/zz.toml
+++ b/modules/map/zz.toml
@@ -1,0 +1,15 @@
+[project]
+version = "0.1.0"
+name = "map"
+cincludes = []
+cobjects = []
+pkgconfig = []
+cflags = []
+
+[dependencies]
+log     = "1"
+mem     = "1"
+buffer  = "1"
+pool    = "1"
+
+[repos]

--- a/tests/mustpass/tail_of_void/src/main.zz
+++ b/tests/mustpass/tail_of_void/src/main.zz
@@ -24,6 +24,11 @@ fn ftail(X+xt * obj) {
     dump(obj, 108);
 }
 
+
+fn wrap(void+vt mut *val, usize expect) {
+    dump(val, expect);
+}
+
 export fn main() -> int {
 
     A a;
@@ -40,9 +45,14 @@ export fn main() -> int {
     u8 mem[19];
     dump(mem, 19);
 
-    X+100 x;
+    X+100 mut x;
     ftail(&x);
     dump(&x, 108);
+
+    dump(slice::slice::Slice{mem: (u8*)"abc", size: 3}, 3);
+
+
+    wrap(&x, 108);
 
     return 0;
 }


### PR DESCRIPTION
we finally have a hashmap.
this implements the minimum viable functions insert/remove/get/iter using the new void tail duck typing mechanism.

insert is implemented as both owned and borrowed keys and values.
users can decide if they want to copy the k/v into the maps memory pool,
or just store a reference which needs to be valid for the lifetime of the map.

additionally this change implements autocast from slice to void tail pointers,
for convenient duck typing into generic containers.

here's a usage example
```C++
  new+1000 t = map::make();
  t.insert_oo("bob", "uncle");
  log::info("%s", t.borrow("bob"));
```

