### PR TITLE
emit negative integer literals into ssa

### DIFF
--- a/modules/slice/src/mut_slice.zz
+++ b/modules/slice/src/mut_slice.zz
@@ -45,6 +45,13 @@ export fn as_slice(MutSlice * self) -> Slice
     return r;
 }
 
+/// return remaining free bytes
+export fn space(MutSlice mut * self) -> usize
+    where   integrity(self)
+{
+    return self->size - *self->at;
+}
+
 /// append the contents of another slice
 export fn append_slice(MutSlice mut * self, Slice other) -> bool
     where   integrity(self)

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -626,8 +626,8 @@ impl Emitter {
                             ast::Expression::LiteralChar { v, .. } => {
                                 f.write(&[*v as u8]).unwrap();
                             }
-                            ast::Expression::Literal { v, loc } => match parser::parse_u64(v) {
-                                Some(v) if v <= 255 => {
+                            ast::Expression::Literal { v, loc } => match parser::parse_int(v) {
+                                Some(parser::Integer::Unsigned(v)) if v <= 255 => {
                                     f.write(&[v as u8]).unwrap();
                                 }
                                 _ => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1890,14 +1890,24 @@ fn unescape(s: &str, loc: &Location) -> Vec<u8> {
     result
 }
 
-pub fn parse_u64(s: &str) -> Option<u64> {
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Integer {
+    Signed(i64),
+    Unsigned(u64),
+}
+
+pub fn parse_int(s: &str) -> Option<Integer> {
     if s.len() > 2 && s.chars().nth(0) == Some('0') && s.chars().nth(1) == Some('x') {
-        return u64::from_str_radix(&s[2..], 16).ok();
+        return u64::from_str_radix(&s[2..], 16).map(|v|Integer::Unsigned(v)).ok();
     }
 
     if let Ok(v) = s.parse::<u64>() {
-        return Some(v);
+        return Some(Integer::Unsigned(v));
+    } else  if let Ok(v) = s.parse::<i64>() {
+        return Some(Integer::Signed(v));
     }
 
     None
 }
+

--- a/tests/mustpass/ssa_signed_int/.gitignore
+++ b/tests/mustpass/ssa_signed_int/.gitignore
@@ -1,0 +1,6 @@
+/target
+.gdb_history
+vgcore.*
+**/*.o
+**/*.parsecache
+**/*.buildcache

--- a/tests/mustpass/ssa_signed_int/src/main.zz
+++ b/tests/mustpass/ssa_signed_int/src/main.zz
@@ -1,0 +1,12 @@
+const i8 THRESHOLD = 10;
+
+pub theory cold(i8 degrees) -> bool
+(
+    degrees < THRESHOLD
+)
+
+export fn main() -> int {
+    i8 temp = -3;
+    static_assert(cold(temp));
+    return 0;
+}

--- a/tests/mustpass/ssa_signed_int/zz.toml
+++ b/tests/mustpass/ssa_signed_int/zz.toml
@@ -1,0 +1,11 @@
+[project]
+version = "0.1.0"
+name = "ssa_signed_int"
+cincludes = []
+cobjects = []
+pkgconfig = []
+cflags = []
+
+[dependencies]
+
+[repos]


### PR DESCRIPTION
wrap and include the sign.
it SHOULD not be nessesary, because literals are bv,
exactly like in machine code, but just in case it does,
we carry the sign until ssa.literal

fixes #112