### PR TITLE
async on windows

### DIFF
--- a/modules/async/src/lib.zz
+++ b/modules/async/src/lib.zz
@@ -41,8 +41,8 @@ export struct Driver+ {
 
 /// construct a default eventloop driver
 export fn system(Driver+maxq mut new * self, err::Err+et mut *e)
-    where err::checked(*e)
-    if #(os::ZZ_ASYNC_URING)
+where err::checked(*e)
+if #(os::ZZ_ASYNC_URING)
 {
     memset(self, 0, sizeof(Driver));
     int r = unsafe<int>(os::io_uring_queue_init(maxq, &self->os.ring, 0));
@@ -51,21 +51,26 @@ export fn system(Driver+maxq mut new * self, err::Err+et mut *e)
         return;
     }
 }
-    else if #(os::ZZ_ASYNC_WIN32)
+else if #(os::ZZ_ASYNC_WIN32)
 {
     memset(self, 0, sizeof(Driver));
+    int r = unsafe<int>(os::io_completion_port_init(&self->os));
+    if r < 0 {
+        e->fail_with_system_error((0-r), "io_completion_port_init(%d)", maxq);
+        return;
+    }
 }
 
 /// wait for futures to complete
 ///
 /// blocks the current thread until either a future completed or a deadline expired
 export fn wait(Driver mut * self, err::Err+et mut* e)
-    where err::checked(*e)
-    if #(os::ZZ_ASYNC_URING)
+where err::checked(*e)
+if #(os::ZZ_ASYNC_URING)
 {
 
     //TODO call here or in wait?
-    unsafe { os::io_uring_submit(&self->os.ring); }
+    unsafe{ os::io_uring_submit(&self->os.ring); }
 
     io_uring_cqe mut * mut cqe = 0;
     int r = unsafe<int>(os::io_uring_wait_cqe(&self->os.ring, &cqe));
@@ -81,17 +86,37 @@ export fn wait(Driver mut * self, err::Err+et mut* e)
     Future mut *fi = (Future mut*)os::io_uring_cqe_get_data(cqe);
     err::assert_safe(fi);
     fi->state = State::Ready;
-    unsafe { fi->os.cqe = cqe; }
+    unsafe{ fi->os.cqe = cqe; }
 
+}
+else if #(os::ZZ_ASYNC_WIN32) {
+    int r = unsafe<int>(os::io_completion_port_wait(&self->os));
+    if r < 0 {
+        e->fail_with_system_error((0-r), "io_completion_port_wait");
+        return;
+    }
+    int count = unsafe<int>(os::io_completion_get_entry_count(&self->os));
+    for(int mut i = 0; i < count; ++i){
+        Future mut *fu = (Future mut*)os::io_completion_get_entry_data(&self->os, i);
+        if fu != 0 {
+            err::assert_safe(fu);
+            unsafe{ fu->os.number_of_bytes_transfered = os::io_completion_get_entry_number_of_bytes_transfered(&self->os, i); }       
+            fu->state = State::Ready;
+        }
+    }
 }
 
 
 export fn take(Future mut *self, err::Err+et mut *e) -> int
-    if #(os::ZZ_ASYNC_URING)
+if #(os::ZZ_ASYNC_URING)
 {
     self->state = State::Invalid;
     int r = unsafe<int>(self->os.cqe->res);
-    unsafe { os::io_uring_cqe_seen(&self->driver->os.ring, self->os.cqe); }
+    unsafe{ os::io_uring_cqe_seen(&self->driver->os.ring, self->os.cqe); }
     return r;
+}
+else if #(os::ZZ_ASYNC_WIN32) {
+    self->state = State::Invalid;
+    return unsafe<int>(self->os.number_of_bytes_transfered);
 }
 

--- a/modules/async/src/os.h
+++ b/modules/async/src/os.h
@@ -1,60 +1,152 @@
 #if defined(__linux__)
-    #define ZZ_ASYNC_UNIX  1
-    #define ZZ_ASYNC_URING 1
+#define ZZ_ASYNC_UNIX 1
+#define ZZ_ASYNC_URING 1
 #elif defined(__APPLE__)
-    #define ZZ_ASYNC_UNIX  1
-    #define ZZ_ASYNC_POLL  1
+#define ZZ_ASYNC_UNIX 1
+#define ZZ_ASYNC_POLL 1
 #elif _WIN32
-    #define ZZ_ASYNC_WIN32 1
+#define ZZ_ASYNC_WIN32 1
 #endif
 
-
 #if ZZ_ASYNC_UNIX
-    #include <errno.h>
-    #include <fcntl.h>
-    #include <stdint.h>
-    #include <stdio.h>
-    #include <string.h>
-    #include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
 
-    typedef struct {
-        int         fd;
-    } async_os_Io;
+typedef struct
+{
+    int fd;
+} async_os_Io;
 #endif
 
 #if ZZ_ASYNC_URING
-    #include <liburing.h>
-    typedef struct {
-        struct io_uring ring;
-    } async_os_Driver;
+#include <liburing.h>
+typedef struct
+{
+    struct io_uring ring;
+} async_os_Driver;
 
-    typedef struct {
-        struct io_uring_sqe * sqe;
-        struct io_uring_cqe * cqe;
-    } async_os_Future;
+typedef struct
+{
+    struct io_uring_sqe *sqe;
+    struct io_uring_cqe *cqe;
+} async_os_Future;
 
 #endif
 
-
 #if ZZ_ASYNC_WIN32
-    #define WIN32_LEAN_AND_MEAN 1
-    #include <windows.h>
-    #include <stdint.h>
-    #include <stdbool.h>
-    #include <winsock2.h>
+#define WIN32_LEAN_AND_MEAN 1
+#include <windows.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <winsock2.h>
 
-    typedef struct {
-        int         fd;
-    } async_os_Io;
+typedef struct
+{
+    WSAOVERLAPPED ol;
+    HANDLE file_handle;
+} async_os_Io;
 
-    typedef struct {
-        HANDLE completion_port;
+typedef struct
+{
+    HANDLE completion_port;
+    OVERLAPPED_ENTRY completion_port_entries[100];
+    DWORD entries_removed;
 
-        bool     has_deadline;
-        uint64_t deadline;
-    } async_os_Driver;
+    bool has_deadline;
+    uint64_t deadline;
+} async_os_Driver;
 
-    typedef struct {
-    } async_os_Future;
+typedef struct
+{
+    HANDLE completion_port;
+    DWORD  number_of_bytes_transfered;
+} async_os_Future;
+
+static inline int open_async_file(async_os_Io *io, const char *filename)
+{
+    io->file_handle = CreateFileA(filename, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_FLAG_OVERLAPPED, NULL);
+    if (io->file_handle == NULL)
+    {
+        return -1;
+    }
+    return 0;
+}
+
+static inline int io_completion_port_init(async_os_Driver *driver)
+{
+    // Create the completion port used by this driver
+    driver->completion_port = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, (ULONG_PTR)NULL, 0);
+    if (driver->completion_port == NULL)
+    {
+        return -1;
+    }
+    return 0;
+}
+
+static inline int io_completion_port_bind(async_os_Io *io, async_os_Future *future, async_os_Driver *driver, void *data)
+{
+    if (future->completion_port != driver->completion_port)
+    {
+        future->completion_port = CreateIoCompletionPort(io->file_handle, driver->completion_port, (ULONG_PTR)data, 0);
+    }
+    if (future->completion_port == NULL)
+    {
+        return -1;
+    }
+    return 0;
+}
+
+static inline int io_completion_port_read(async_os_Io *io, uint8_t *mem, size_t size)
+{
+    if (FALSE == ReadFile(io->file_handle, mem, size, NULL, &io->ol) && GetLastError() != ERROR_IO_PENDING)
+    {
+        return -1;
+    }
+    return 0;
+}
+
+static inline int io_completion_port_write(async_os_Io *io, const uint8_t *mem, size_t size)
+{
+    if (FALSE == WriteFile(io->file_handle, mem, size, NULL, &io->ol) && GetLastError() != ERROR_IO_PENDING)
+    {
+        return -1;
+    }
+    return 0;
+}
+
+static inline int io_completion_port_wait(async_os_Driver *driver)
+{
+    driver->entries_removed = 0;
+    if (FALSE == GetQueuedCompletionStatusEx(driver->completion_port,
+                                             driver->completion_port_entries, sizeof(driver->completion_port_entries) / sizeof(driver->completion_port_entries[0]),
+                                             &driver->entries_removed,
+                                             driver->has_deadline ? driver->deadline : INFINITE,
+                                             FALSE))
+    {
+        return -1;
+    }
+    return 0;
+}
+
+static inline int io_completion_get_entry_count(async_os_Driver *driver)
+{
+    return driver->entries_removed;
+}
+
+static inline void *io_completion_get_entry_data(async_os_Driver *driver, const int i)
+{
+    if(driver->completion_port_entries[i].lpOverlapped == NULL)
+        return NULL;
+    return (void*)driver->completion_port_entries[i].lpCompletionKey;
+}
+
+static inline DWORD io_completion_get_entry_number_of_bytes_transfered(async_os_Driver *driver, const int i)
+{
+    return driver->completion_port_entries[i].dwNumberOfBytesTransferred;
+}
 
 #endif

--- a/modules/async/src/stdio.zz
+++ b/modules/async/src/stdio.zz
@@ -10,28 +10,36 @@ export struct Stdio
 }
 
 export fn stdin(Stdio mut new * self, err::Err+et mut* e)
-    where err::checked(*e)
+where err::checked(*e)
 if #(os::ZZ_ASYNC_UNIX)
 {
-    unsafe {
+    unsafe{
         self->os.fd = os::fileno(os::stdin);
     }
     make_async(unsafe<int>(self->os.fd), e);
 }
+else if #(os::ZZ_ASYNC_WIN32) {
+    unsafe<int>(open_async_file(&self->os, "CONIN$"));
+    // todo error handling
+}
 
 export fn stdout(Stdio mut new * self, err::Err+et mut* e)
-    where err::checked(*e)
+where err::checked(*e)
 if #(os::ZZ_ASYNC_UNIX)
 {
-    unsafe {
+    unsafe{
         self->os.fd = os::fileno(os::stdout);
     }
     make_async(unsafe<int>(self->os.fd), e);
 }
+else if #(os::ZZ_ASYNC_WIN32) {
+    unsafe<int>(open_async_file(&self->os, "CONOUT$"));
+    // todo error handling    
+}
 
 pub fn make_async(int fd, err::Err+et mut* e)
-    where err::checked(*e)
-    if #(os::defined(os::ZZ_ASYNC_UNIX))
+where err::checked(*e)
+if #(os::defined(os::ZZ_ASYNC_UNIX))
 {
     int mut flags = unsafe<int>(os::fcntl(fd, os::F_GETFL, 0));
     if (flags == -1) {
@@ -50,24 +58,34 @@ pub fn read(
     err::Err+et mut* e,
     slice::MutSlice to,
     async::Future new mut *future,
-)
-    where err::checked(*e)
-    if #(os::defined(os::ZZ_ASYNC_URING))
+    )
+where err::checked(*e)
+if #(os::defined(os::ZZ_ASYNC_URING))
 {
-    unsafe {
+    unsafe{
         future->os.sqe = os::io_uring_get_sqe(&future->driver->os.ring);
     }
-    if !unsafe<bool>(future->os.sqe) {
-        e->fail(err::OutOfTail, "maxq");
-        return;
-    }
+        if !unsafe<bool>(future->os.sqe) {
+            e->fail(err::OutOfTail, "maxq");
+            return;
+        }
 
-    unsafe {
+    unsafe{
         os::io_uring_prep_read(future->os.sqe, self->os.fd, (u8 mut *)to.mem, to.size, *to.at);
         os::io_uring_sqe_set_data(future->os.sqe, future);
     }
 
-    //FIXME how to store and advance to->at ?
+        //FIXME how to store and advance to->at ?
+}
+else if #(os::ZZ_ASYNC_WIN32) {
+    int r1 = unsafe<int>(os::io_completion_port_bind(&self->os, &future->os, &future->driver->os, future));
+    if r1 < 0 {
+        e->fail_with_system_error((0-r1), "io_completion_port_bind(%d)", "maxq");
+    }
+    int r2 = unsafe<int>(os::io_completion_port_read(&self->os, (u8 mut *)to.mem, to.size));
+    if r2 < 0 {
+        e->fail_with_system_error((0-r2), "io_completion_port_read(%d)", "maxq");
+    }
 }
 
 pub fn write(
@@ -75,20 +93,31 @@ pub fn write(
     err::Err+et mut* e,
     slice::Slice to,
     async::Future new mut *future,
-)
-    where err::checked(*e)
-    if #(os::defined(os::ZZ_ASYNC_URING))
+    )
+where err::checked(*e)
+if #(os::defined(os::ZZ_ASYNC_URING))
 {
-    unsafe {
+    unsafe{
         future->os.sqe = os::io_uring_get_sqe(&future->driver->os.ring);
     }
-    if !unsafe<bool>(future->os.sqe) {
-        e->fail(err::OutOfTail, "maxq");
-        return;
-    }
 
-    unsafe {
+        if !unsafe<bool>(future->os.sqe) {
+            e->fail(err::OutOfTail, "maxq");
+            return;
+        }
+
+    unsafe{
         os::io_uring_prep_write(future->os.sqe, self->os.fd, (u8 *)to.mem, to.size, 0);
-        os::io_uring_sqe_set_data(future->os.sqe, future);
+    os::io_uring_sqe_set_data(future->os.sqe, future);
+    }
+}
+else if #(os::ZZ_ASYNC_WIN32) {
+    int r1 = unsafe<int>(os::io_completion_port_bind(&self->os, &future->os, &future->driver->os, future));
+    if r1 < 0 {
+        e->fail_with_system_error((0-r1), "io_completion_port_bind(%d)", "maxq");
+    }
+    int r2 = unsafe<int>(os::io_completion_port_write(&self->os, (u8 *)to.mem, to.size));
+    if r2 < 0 {
+        e->fail_with_system_error((0-r2), "io_completion_port_write(%d)", "maxq");
     }
 }


### PR DESCRIPTION
Hi Arvid,

I did a rebase on master with your async branch and added a basic windows implementation for async read and write for console input and output. The async test application is working so far. As conclusion could be said that your async API design should basically work on windows.

Something that could be better for the windows async would be if the driver is put where you create the "device". So instead of 
`new input = async::stdio::stdin(&e);`
do
`new input = async::stdio::stdin(&e, &driver);`
because now the "binding" between driver and "device", happens lazy when the first read / write is executed. 
But that is totally your decision, and maybe there are reasons of that API design as it is.

Regards 

Tobias

