### PR TITLE
macros: do not emit incomplete c

### DIFF
--- a/src/abs.rs
+++ b/src/abs.rs
@@ -599,6 +599,7 @@ fn abs_expr(
 
             match makro::expr(name, loc, args) {
                 Ok(expr2) => {
+                    log::debug!("abs macro complete {} {}", name, loc);
                     *expr = expr2;
                     abs_expr(expr, scope, inbody, all_modules, self_md_name);
                 }
@@ -607,6 +608,7 @@ fn abs_expr(
                         emit_error(e.message, &e.details);
                         std::process::exit(9);
                     } else {
+                        log::debug!("abs incomplete because of macro {} {}", name, loc);
                         scope.complete.replace(false);
                     }
                 }

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -1491,7 +1491,8 @@ impl Emitter {
                 self.emit_expr(expr);
             }
             ast::Expression::MacroCall { loc, .. } => {
-                write!(self.f, "{{INTERNAL_ERROR_MACRO_NOT_EXPANDED}}").unwrap();
+                emit_error(format!("internal compiler error"), &[(loc.clone(), "ICE: macro not available yet")]);
+                std::process::exit(9);
             }
             ast::Expression::ArrayInit { fields, loc } => {
                 self.emit_loc(&loc);

--- a/src/main.rs
+++ b/src/main.rs
@@ -521,7 +521,9 @@ fn main() {
                 submatches.value_of("variant").unwrap_or("default"),
                 stage,
                 submatches.is_present("slow"),
-            )
+            );
+
+            println!("success");
         }
         ("", None) => {
             zz::build(zz::BuildSet::All, "default", zz::make::Stage::test(), false);

--- a/src/makro.rs
+++ b/src/makro.rs
@@ -30,7 +30,7 @@ pub fn expr(
     ;
     if !mp.exists() {
         return Err(Error::new(
-            format!("macro {} is unavailable", name),
+            format!("macro {} is unavailable (exe {:?})", name, mp),
             vec![(
                 loc.clone(),
                 "macro not available here. it may be compiled later".to_string(),
@@ -156,6 +156,9 @@ pub fn stm(
     Ok(statements)
 }
 
+
+
+//for each macro, create a new module with the macro being main
 pub fn sieve(md: &ast::Module) -> Vec<ast::Module> {
     let mut newmods = Vec::new();
     for local in &md.locals {


### PR DESCRIPTION
Emitting a broken C file was always a barely functional workaround.
Instead not emit anything and try harder to retry emission in the next
artifact iteration when the c file can be emitted completely.

This breaks some same-file macros for now, because makro::sieve really
shouldnt just copy the whole module