### PR TITLE
do not convert string to rust String

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -474,7 +474,7 @@ pub enum Expression {
     },
     LiteralString {
         loc: Location,
-        v: String,
+        v:  Vec<u8>,
     },
     LiteralChar {
         loc: Location,

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -623,8 +623,8 @@ impl Emitter {
 
                     // TODO this is a hack to work around string literals containing
                     // native file endings
-                    v.retain(|i| i != '\r');
-                    f.write_all(v.as_bytes()).unwrap();
+                    v.retain(|i| *i != b'\r');
+                    f.write_all(&v).unwrap();
                 }
                 ast::Expression::ArrayInit { fields, .. } => {
                     for field in fields {
@@ -1208,7 +1208,9 @@ impl Emitter {
                                         std::process::exit(9);
                                     }
                                     if let ast::Expression::LiteralString{v,..} = args[0].as_ref() {
-                                        write!(self.f, "#pragma comment(linker, \"{}\")\n", v).unwrap();
+                                        write!(self.f, "#pragma comment(linker, \"").unwrap();
+                                        self.f.write(&v).unwrap();
+                                        write!(self.f, "\")\n").unwrap();
                                         continue;
                                     } else {
                                         emit_error(format!("invalid flags statement"),
@@ -1567,7 +1569,7 @@ impl Emitter {
             ast::Expression::LiteralString { loc, v } => {
                 self.emit_loc(&loc);
                 write!(self.f, "    \"").unwrap();
-                for c in v.as_bytes() {
+                for c in v {
                     self.write_escaped_literal(*c, true);
                 }
                 write!(self.f, "\"").unwrap();

--- a/src/emitter_rs.rs
+++ b/src/emitter_rs.rs
@@ -356,7 +356,6 @@ impl Emitter {
         };
 
         let fieldval = match expr {
-            ast::Expression::LiteralString { v, .. } => format!("b\"{}\".as_ptr()", v),
             ast::Expression::LiteralChar { v, .. } => format!("'{}'", v),
             ast::Expression::Literal { v, .. } => format!("{}", v),
             _ => {
@@ -821,7 +820,7 @@ impl {name} {{
             ast::Expression::LiteralString { loc, v } => {
                 self.emit_loc(&loc);
                 write!(self.f, "    \"").unwrap();
-                for c in v.as_bytes() {
+                for c in v {
                     self.write_escaped_literal(*c, true);
                 }
                 write!(self.f, "\"").unwrap();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -989,7 +989,7 @@ pub(crate) fn parse_expr_inner(n: &str, expr: pest::iterators::Pair<'static, Rul
             };
 
             Expression::LiteralString {
-                v: String::from_utf8_lossy(&v).to_string(),
+                v,
                 loc,
             }
         }
@@ -1859,7 +1859,7 @@ fn unescape(s: &str, loc: &Location) -> Vec<u8> {
                         .fold(0, |acc, c| acc * 16 + c.to_digit(16).unwrap());
                     if value > 255 {
                         emit_error(
-                            "octal value too big for char",
+                            "hex value too big for char",
                             &[(loc.clone(), "in this literal string")],
                         );
                         std::process::exit(9);

--- a/src/symbolic.rs
+++ b/src/symbolic.rs
@@ -1642,7 +1642,7 @@ impl Symbolic {
                 let lit = match v.as_str() {
                     "file" => ast::Expression::LiteralString {
                         loc: loc.clone(),
-                        v: callloc.file.clone(),
+                        v: callloc.file.clone().into_bytes(),
                     },
                     "line" => ast::Expression::Literal {
                         loc: loc.clone(),
@@ -1650,11 +1650,11 @@ impl Symbolic {
                     },
                     "module" => ast::Expression::LiteralString {
                         loc: loc.clone(),
-                        v: self.current_module_name.clone(),
+                        v: self.current_module_name.clone().into_bytes(),
                     },
                     "function" => ast::Expression::LiteralString {
                         loc: loc.clone(),
-                        v: self.current_function_name.clone(),
+                        v: self.current_function_name.clone().into_bytes(),
                     },
                     _ => {
                         return Err(self.trace(
@@ -2379,7 +2379,7 @@ impl Symbolic {
             }
             ast::Expression::LiteralString { loc, v } => {
                 let tmp = self.temporary(
-                    format!("literal string \"{}\"", v),
+                    format!("literal string \"{}\"", String::from_utf8_lossy(&v)),
                     ast::Typed {
                         t: ast::Type::U8,
                         loc: loc.clone(),
@@ -4386,7 +4386,7 @@ pub fn execute(
                 if derive.makro == "solver" {
                     match derive.args.first().map(|x| *x.clone()) {
                         Some(ast::Expression::LiteralString { v, .. }) => {
-                            solver = Some(v);
+                            solver = Some(String::from_utf8_lossy(&v).to_string());
                         }
                         _ => {
                             parser::emit_error(

--- a/tests/mustpass/escape/src/main.zz
+++ b/tests/mustpass/escape/src/main.zz
@@ -4,10 +4,10 @@ using <string.h>::{strlen};
 
 export fn main() -> int {
     char c1 = ' ';
-    char c2 = '\x12';
+    char c2 = '\x8c';
     char c3 = '\'';
 
-    char *str = "abc123 \' \" \? \\ \a \b \f \n \r \t \v \x12 \x12 abc1923u123    {} 23[123 ";
+    char *str = "\x8c abc123 \' \" \? \\ \a \b \f \n \r \t \v \x12 \x12 abc1923u123    {} 23[123 ";
     assert(static(len(str)) == strlen(str) + 1);
     return 0;
 }


### PR DESCRIPTION
rust does utf8 conversion, which actually breaks user code that does its own encoding.
we could probably separate out strings into bytestrings and utf8strings
like rust does it, but we dont have any utf8 implementation and neither
does C