### PR TITLE
callsite assign

### DIFF
--- a/modules/ast/src/lib.zz
+++ b/modules/ast/src/lib.zz
@@ -172,11 +172,11 @@ export struct Ast+
     pool::Pool+     mut pl;
 }
 
-pub fn from_macro(Ast+t mut new *self)
-    where t > t/64
+pub fn from_macro(Ast mut new *self, usize tail = static(len(self->pl.pmem)))
+    where tail > tail/64
     model(vec::integrity(&self->args))
 {
-    self->pl.make(64);
+    self->pl.make(64, tail);
     self->args.make_with_pool(&self->pl);
     new+1000 e = err::make();
     new+1000 p = json::parser(&e, json::U{

--- a/modules/ast/src/parser.zz
+++ b/modules/ast/src/parser.zz
@@ -12,7 +12,7 @@ using <string.h>::{memcpy, strncat};
 
 export symbol ParseError;
 
-fn parse_v_string_array(json::U *u, err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn parse_v_string_array(json::U *u, err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
 {
     let pl = (pool::Pool mut*)u->user2;
     static_attest(safe(pl));
@@ -39,7 +39,7 @@ fn parse_v_string_array(json::U *u, err::Err+et mut *e, json::Parser+pt mut* p, 
     }
 }
 
-fn parse_v(json::U *u, err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn parse_v(json::U *u, err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
     where nullterm(k)
 {
@@ -82,7 +82,7 @@ fn parse_v(json::U *u, err::Err+et mut *e, json::Parser+pt mut* p, char *k, json
     }
 }
 
-fn parse_t(json::U *u, err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn parse_t(json::U *u, err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
     where nullterm(k)
 {
@@ -94,6 +94,16 @@ fn parse_t(json::U *u, err::Err+et mut *e, json::Parser+pt mut* p, char *k, json
 
     if buffer::cstr_eq(k, "t") {
         switch v.t {
+            json::ValueType::String => {
+                static_attest(safe(v.string));
+                static_attest(nullterm(v.string));
+                char mut * dup = pl->malloc(buffer::strlen(v.string) + 1);
+                memcpy(dup, v.string, buffer::strlen(v.string));
+                arg->v.string = slice::slice::Slice{
+                    mem:    (u8*)dup,
+                    size:   buffer::strlen(v.string) + 1,
+                };
+            }
             json::ValueType::Object => {
                 json::next(p,  e, json::U{
                     it: parse_t_other,
@@ -110,7 +120,7 @@ fn parse_t(json::U *u, err::Err+et mut *e, json::Parser+pt mut* p, char *k, json
     }
 }
 
-fn parse_t_other(json::U *u, err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn parse_t_other(json::U *u, err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
     where nullterm(k)
 {
@@ -120,7 +130,7 @@ fn parse_t_other(json::U *u, err::Err+et mut *e, json::Parser+pt mut* p, char *k
     let arg = (ast::Expression mut*)u->user1;
     static_attest(safe(arg));
 
-    if buffer::cstr_eq(k, "Other") {
+    if buffer::cstr_eq(k, "other") {
         switch v.t {
             json::ValueType::Array => {
                 json::next(p,  e, json::U{
@@ -138,7 +148,7 @@ fn parse_t_other(json::U *u, err::Err+et mut *e, json::Parser+pt mut* p, char *k
     }
 }
 
-fn parse_t_other_value(json::U *u, err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn parse_t_other_value(json::U *u, err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
     where nullterm(k)
 {
@@ -183,7 +193,7 @@ fn parse_t_other_value(json::U *u, err::Err+et mut *e, json::Parser+pt mut* p, c
     }
 }
 
-fn parse_expression_infix(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn parse_expression_infix(json::U *u,  err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
     where nullterm(k)
 {
@@ -232,7 +242,7 @@ fn parse_expression_infix(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* 
     }
 }
 
-fn parse_expression_call(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn parse_expression_call(json::U *u,  err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
     where nullterm(k)
 {
@@ -264,7 +274,7 @@ fn parse_expression_call(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p
 
 }
 
-fn parse_expression(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn parse_expression(json::U *u,  err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
     where nullterm(k)
 {
@@ -276,7 +286,7 @@ fn parse_expression(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, cha
 
     switch v.t {
         json::ValueType::Object => {
-            if buffer::cstr_eq(k, "Literal") {
+            if buffer::cstr_eq(k, "literal") {
                 arg->t = ast::ExpressionType::Literal;
                 json::next(p,  e, json::U{
                     it:parse_v,
@@ -286,7 +296,7 @@ fn parse_expression(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, cha
                 if err::check(e) {
                     return;
                 }
-            } else if buffer::cstr_eq(k, "LiteralString") {
+            } else if buffer::cstr_eq(k, "literal_string") {
                 arg->t = ast::ExpressionType::LiteralString;
                 json::next(p,  e, json::U{
                     it:     parse_v,
@@ -296,7 +306,7 @@ fn parse_expression(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, cha
                 if err::check(e) {
                     return;
                 }
-            } else if buffer::cstr_eq(k, "Name") {
+            } else if buffer::cstr_eq(k, "name") {
                 arg->t = ast::ExpressionType::Name;
                 json::next(p,  e, json::U{
                     it:     parse_t,
@@ -306,7 +316,7 @@ fn parse_expression(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, cha
                 if err::check(e) {
                     return;
                 }
-            } else if buffer::cstr_eq(k, "Infix") {
+            } else if buffer::cstr_eq(k, "infix") {
                 arg->t = ast::ExpressionType::Infix;
                 arg->v.infix.make_infix_expression(pl);
                 json::next(p,  e, json::U{
@@ -317,7 +327,7 @@ fn parse_expression(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, cha
                 if err::check(e) {
                     return;
                 }
-            } else if buffer::cstr_eq(k, "Call") {
+            } else if buffer::cstr_eq(k, "call") {
                 arg->t = ast::ExpressionType::Call;
                 arg->v.call.make_call_expression(pl);
                 json::next(p,  e, json::U{
@@ -333,13 +343,13 @@ fn parse_expression(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, cha
             }
         }
         default => {
-            err::fail(e, ParseError, "got %s expected Literal | LiteralString ", k);
+            err::fail(e, ParseError, "unable to parse %s ", k);
         }
     }
 }
 
 
-fn parse_arglist(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn parse_arglist(json::U *u,  err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
     where nullterm(k)
 {
@@ -378,7 +388,7 @@ fn parse_arglist(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *
 }
 
 
-fn parse_typed_other(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn parse_typed_other(json::U *u,  err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
     where nullterm(k)
 {
@@ -413,7 +423,7 @@ fn parse_typed_other(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, ch
     }
 }
 
-fn parse_typed_ptr(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn parse_typed_ptr(json::U *u,  err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
     where nullterm(k)
 {
@@ -429,7 +439,7 @@ fn parse_typed_ptr(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char
     }
 }
 
-fn parse_typed_params(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn parse_typed_params(json::U *u,  err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
     where nullterm(k)
 {
@@ -462,7 +472,7 @@ fn parse_typed_params(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, c
 }
 
 
-fn parse_typed(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn parse_typed(json::U *u,  err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
     where nullterm(k)
 {
@@ -487,7 +497,7 @@ fn parse_typed(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k,
         if err::check(e) {
             return;
         }
-    } else if buffer::cstr_eq(k, "Other") && v.t == json::ValueType::Array {
+    } else if buffer::cstr_eq(k, "other") && v.t == json::ValueType::Array {
         json::next(p,  e, json::U{
             it: parse_typed_other,
             user1: u->user1,
@@ -517,7 +527,7 @@ fn parse_typed(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k,
     }
 }
 
-fn parse_field(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn parse_field(json::U *u,  err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
     where nullterm(k)
 {
@@ -551,7 +561,7 @@ fn parse_field(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k,
     }
 }
 
-fn parse_struct_fields(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn parse_struct_fields(json::U *u,  err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
     where nullterm(k)
 {
@@ -582,7 +592,7 @@ fn parse_struct_fields(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, 
     }
 }
 
-fn parse_struct(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn parse_struct(json::U *u,  err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
     where nullterm(k)
 {
@@ -598,7 +608,7 @@ fn parse_struct(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k
     }
 }
 
-fn parse_enum_name(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn parse_enum_name(json::U *u,  err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
     where nullterm(k)
 {
@@ -619,7 +629,7 @@ fn parse_enum_name(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char
     }
 }
 
-fn parse_enum_names(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn parse_enum_names(json::U *u,  err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
     where nullterm(k)
 {
@@ -649,7 +659,7 @@ fn parse_enum_names(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, cha
     }
 }
 
-fn parse_enum(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn parse_enum(json::U *u,  err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
     where nullterm(k)
 {
@@ -665,7 +675,7 @@ fn parse_enum(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k, 
     }
 }
 
-fn parse_typealias(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn parse_typealias(json::U *u,  err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
     where nullterm(k)
 {
@@ -687,7 +697,7 @@ fn parse_typealias(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char
     }
 }
 
-fn parse_def(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn parse_def(json::U *u,  err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
     where nullterm(k)
 {
@@ -697,7 +707,7 @@ fn parse_def(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k, j
     let aa = (ast::Ast mut*)u->user1;
     static_attest(safe(aa));
 
-    if buffer::cstr_eq(k, "Struct") && v.t == json::ValueType::Object {
+    if buffer::cstr_eq(k, "struct") && v.t == json::ValueType::Object {
         aa->local.t = ast::DefType::Struct;
         aa->local.v.dstruct.make_def_struct(pl);
         json::next(p,  e, json::U{
@@ -708,7 +718,7 @@ fn parse_def(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k, j
         if err::check(e) {
             return;
         }
-    } else if buffer::cstr_eq(k, "Enum") && v.t == json::ValueType::Object {
+    } else if buffer::cstr_eq(k, "enum") && v.t == json::ValueType::Object {
         aa->local.t = ast::DefType::Enum;
         aa->local.v.denum.make_def_enum(pl);
         json::next(p,  e, json::U{
@@ -719,7 +729,7 @@ fn parse_def(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k, j
         if err::check(e) {
             return;
         }
-    } else if buffer::cstr_eq(k, "Type") && v.t == json::ValueType::Object {
+    } else if buffer::cstr_eq(k, "type") && v.t == json::ValueType::Object {
         aa->local.t = ast::DefType::Type;
         aa->local.v.dalias.make_def_alias(pl);
         json::next(p,  e, json::U{
@@ -733,7 +743,7 @@ fn parse_def(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k, j
     }
 }
 
-fn parse_local(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn parse_local(json::U *u,  err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
     where nullterm(k)
 {
@@ -762,7 +772,7 @@ fn parse_local(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k,
     }
 }
 
-pub fn parse_doc(json::U *u,  err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+pub fn parse_doc(json::U *u,  err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
     where nullterm(k)
 {

--- a/modules/buffer/src/lib.zz
+++ b/modules/buffer/src/lib.zz
@@ -10,45 +10,83 @@ using <string.h>::{memset};
 /// a byte buffer, with guaranted terminating null byte
 export struct Buffer+ {
     usize   at;
+    usize   size;
     char    mem[];
 }
 
-pub theory integrity(Buffer*self, usize tail) -> bool
+pub theory integrity(Buffer*self) -> bool
 (
     safe(self)
-    && len(self->mem) >= tail
+    && len(self->mem) >= self->size
     && self->at < len(self->mem)
+    && self->at < self->size
     && nullterm(self->mem)
 )
 
 /// make an empty buffer
-export fn make(Buffer+tail mut new* self)
+export fn make(Buffer mut new* self, usize tail = static(len(self->mem)))
     where tail > 0
-    model integrity(self, tail)
+    model integrity(self)
+    model self->size == tail
 {
-    clear(self)
+    self->size = tail;
+    self->at = 0;
+    mem::set(self->mem, 0, self->size);
+    static_attest(nullterm(self->mem));
 }
 
+/// make a buffer by copying a c string
+export fn from_cstr(Buffer new mut* self, char *s, usize tail = static(len(self->mem)))
+    where   tail > 0
+    where   nullterm(s)
+    model   integrity(self)
+{
+    make(self, tail);
+    self->append_cstr(s)
+}
+
+/// make a buffer by copying raw bytes with given len
+export fn from_bytes(Buffer new mut* self, u8* bytes, usize mut inlen, usize tail = static(len(self->mem)))
+    where   tail > 0
+    where   len(bytes) >= inlen
+    model   integrity(self)
+{
+    make(self, tail);
+    self->append_bytes(bytes, inlen);
+}
+
+/// make a buffer by copying a slice
+export fn from_slice(Buffer new mut* self, Slice slice, usize tail = static(len(self->mem)))
+    where   tail > 0
+    where   slicem::slice::integrity(&slice)
+    model   integrity(self)
+{
+    make(self, tail);
+    self->append_slice(slice)
+}
+
+
+
 /// clear the buffer
-export fn clear(Buffer+tail mut new* self)
-    where tail > 0
-    model integrity(self, tail)
+export fn clear(Buffer mut new* self)
+    where integrity(self)
+    model integrity(self)
 {
     self->at = 0;
-    mem::set(self->mem, 0, tail);
+    mem::set(self->mem, 0, self->size);
     static_attest(nullterm(self->mem));
 }
 
 /// length of buffer (excluding null terminator)
-export fn slen(Buffer+tail * self) -> usize
-    where integrity(self, tail)
+export fn slen(Buffer * self) -> usize
+    where integrity(self)
 {
     return self->at;
 }
 
 /// buffer as null terminated c buffer
-export fn cstr(Buffer+tail * self) -> char *
-    where integrity(self, tail)
+export fn cstr(Buffer * self) -> char *
+    where integrity(self)
     model safe(return)
     model nullterm(return)
 {
@@ -56,8 +94,8 @@ export fn cstr(Buffer+tail * self) -> char *
 }
 
 /// create slice pointing to used memory of this buffer, excluding null terminator
-export fn as_slice(Buffer+tail * self) -> Slice
-    where integrity(self, tail)
+export fn as_slice(Buffer * self) -> Slice
+    where integrity(self)
     model slicem::slice::integrity(&return)
 {
     new sl = slicem::slice::make((u8*)self->mem, self->at);
@@ -72,20 +110,20 @@ export fn as_slice(Buffer+tail * self) -> Slice
 /// you need to manually attest that the mutslice does not cause
 /// the last byte to be overwritten and then call static_attest(buffer::integrity(buf))
 ///
-export fn as_mut_slice(Buffer+tail mut * self) -> MutSlice
-    where integrity(self, tail)
+export fn as_mut_slice(Buffer mut * self) -> MutSlice
+    where integrity(self)
     model slicem::mut_slice::integrity(&return)
 {
-    new sl = slicem::mut_slice::make((u8 mut*)self->mem, tail, &self->at);
+    new sl = slicem::mut_slice::make((u8 mut*)self->mem, self->size, &self->at);
     return sl;
 }
 
 /// push a single byte
-export fn push(Buffer+t mut * self, char b) -> bool
-    where   integrity(self, t)
-    model   integrity(self, t)
+export fn push(Buffer mut * self, char b) -> bool
+    where   integrity(self)
+    model   integrity(self)
 {
-    if t < 2 || self->at > t - 2 {
+    if self->size < 2 || self->at > self->size - 2 {
         return false;
     }
 
@@ -98,9 +136,9 @@ export fn push(Buffer+t mut * self, char b) -> bool
 /// remove the last byte
 ///
 /// returns false if buffer was empty
-export fn pop(Buffer+t mut * self) -> bool
-    where   integrity(self, t)
-    model   integrity(self, t)
+export fn pop(Buffer mut * self) -> bool
+    where   integrity(self)
+    model   integrity(self)
 {
     if self->at == 0 {
         return false;
@@ -131,19 +169,19 @@ export fn strlen(char * mut s) -> usize
 /// returns the amount of bytes still left in the tail
 ///
 /// note that one byte is always reserved for null terminator
-export fn available(Buffer+tail *self) -> usize
-    where integrity(self, tail)
-    model return == tail - self->at - 1
-    model return < tail
+export fn available(Buffer *self) -> usize
+    where integrity(self)
+    model return == self->size - self->at - 1
+    model return < self->size
 {
-    return tail - self->at - 1;
+    return self->size - self->at - 1;
 }
 
 /// append a null terminated c buffer
-export fn append_cstr(Buffer+t mut * self, char * cstr)
+export fn append_cstr(Buffer mut * self, char * cstr)
     where   nullterm(cstr)
-    where   integrity(self, t)
-    model   integrity(self, t)
+    where   integrity(self)
+    model   integrity(self)
 {
 
     usize rest = self->available();
@@ -158,10 +196,10 @@ export fn append_cstr(Buffer+t mut * self, char * cstr)
 }
 
 /// append a slice
-export fn append_slice(Buffer+t mut* self, Slice slice)
+export fn append_slice(Buffer mut* self, Slice slice)
     where   slicem::slice::integrity(&slice)
-    where   integrity(self, t)
-    model   integrity(self, t)
+    where   integrity(self)
+    model   integrity(self)
 {
     usize rest = self->available();
     usize mut inlen = slice.size;
@@ -175,10 +213,10 @@ export fn append_slice(Buffer+t mut* self, Slice slice)
 }
 
 /// append raw bytes with given len
-export fn append_bytes(Buffer+t mut* self, u8* bytes, usize mut inlen)
+export fn append_bytes(Buffer mut* self, u8* bytes, usize mut inlen)
     where   len(bytes) >= inlen
-    where   integrity(self, t)
-    model   integrity(self, t)
+    where   integrity(self)
+    model   integrity(self)
 {
     usize rest = self->available();
     if (inlen > rest) {
@@ -191,10 +229,10 @@ export fn append_bytes(Buffer+t mut* self, u8* bytes, usize mut inlen)
 }
 
 /// append formated string with vsnprintf
-export fn format(Buffer+tail mut * self, char *fmt, ...) -> int
+export fn format(Buffer mut * self, char *fmt, ...) -> int
     where   nullterm(fmt)
-    where   integrity(self, tail)
-    model   integrity(self, tail)
+    where   integrity(self)
+    model   integrity(self)
 {
     va_list mut args;
     va_start (args, fmt);
@@ -204,10 +242,10 @@ export fn format(Buffer+tail mut * self, char *fmt, ...) -> int
     return r;
 }
 
-export fn vformat(Buffer+tail mut * self, char *fmt, va_list mut args) -> int
+export fn vformat(Buffer mut * self, char *fmt, va_list mut args) -> int
     where   nullterm(fmt)
-    where   integrity(self, tail)
-    model   integrity(self, tail)
+    where   integrity(self)
+    model   integrity(self)
 {
     usize isfree = self->available();
 
@@ -233,16 +271,18 @@ export fn vformat(Buffer+tail mut * self, char *fmt, va_list mut args) -> int
 }
 
 /// test if this buffer is equal with a c string
-export fn eq_cstr(Buffer+tail* self, char * unsafe b) -> bool
+export fn eq_cstr(Buffer * self, char * unsafe b) -> bool
     where   nullterm(b)
-    where   integrity(self, tail)
+    where   integrity(self)
 {
+    let l1 = strlen(self->mem);
+
     if b == 0 {
         return self->at == 0;
     }
     static_attest(safe(b));
     let l2 = strlen(b);
-    if l2 != self->at {
+    if l2 != l1 {
         return false;
     }
     return mem::eq(self->mem, b, l2);
@@ -267,9 +307,9 @@ export fn cstr_eq(char *unsafe a, char * unsafe b) -> bool
 }
 
 /// test if this buffer begins with some c string
-export fn starts_with_cstr(Buffer+tail* self, char *unsafe a) -> bool
+export fn starts_with_cstr(Buffer * self, char *unsafe a) -> bool
     where   a == 0 || nullterm(a)
-    where   integrity(self, tail)
+    where   integrity(self)
 {
     if a == 0 {
         return self->at == 0;
@@ -283,9 +323,9 @@ export fn starts_with_cstr(Buffer+tail* self, char *unsafe a) -> bool
 }
 
 /// test if self ends with other buffer
-export fn ends_with_cstr(Buffer+tail *self, char *unsafe a) -> bool
+export fn ends_with_cstr(Buffer *self, char *unsafe a) -> bool
     where   a == 0 || nullterm(a)
-    where   integrity(self, tail)
+    where   integrity(self)
 {
     if a == 0 {
         return self->at == 0;
@@ -301,10 +341,10 @@ export fn ends_with_cstr(Buffer+tail *self, char *unsafe a) -> bool
 }
 
 /// append to this buffer by reading a line from a FILE
-export fn fgets(Buffer+tail mut* self, FILE mut * unsafe stream) -> bool
-    where   integrity(self, tail)
+export fn fgets(Buffer mut* self, FILE mut * unsafe stream) -> bool
+    where   integrity(self)
 {
-    char *rr = unsafe<char*>(native::xN_fgets(self->mem + self->at, tail - self->at, stream));
+    char *rr = unsafe<char*>(native::xN_fgets(self->mem + self->at, self->size - self->at, stream));
     if rr == 0 {
         return false;
     }
@@ -317,11 +357,11 @@ export fn fgets(Buffer+tail mut* self, FILE mut * unsafe stream) -> bool
 }
 
 /// append parts of this buffer to other buffer
-export fn substr(Buffer+tail *self, usize from, usize mut size, Buffer+tail2 mut * other)
-    where   integrity(self, tail)
-    where   integrity(other, tail2)
-    model   integrity(self, tail)
-    model   integrity(other, tail2)
+export fn substr(Buffer *self, usize from, usize mut size, Buffer mut * other)
+    where   integrity(self)
+    where   integrity(other)
+    model   integrity(self)
+    model   integrity(other)
 {
     if self->at == 0 {
         return;
@@ -339,11 +379,11 @@ export fn substr(Buffer+tail *self, usize from, usize mut size, Buffer+tail2 mut
     //printf("A len1: %zu, len2: %zu, from: %zu, size: %zu\n",
     //    self->islice.at, other->islice.at, from, size);
 
-    if other->at + size + 1 >= tail2 {
-        if other->at + 1 >= tail2 {
+    if other->at + size + 1 >= other->size {
+        if other->at + 1 >= other->size {
             return;
         }
-        size = tail2 - 1 - other->at;
+        size = other->size - 1 - other->at;
     }
 
 
@@ -355,7 +395,7 @@ export fn substr(Buffer+tail *self, usize from, usize mut size, Buffer+tail2 mut
     }
 
     //TODO i'm not sure what ssa is confused about
-    static_attest(size + other->at < tail2);
+    static_attest(size + other->at < other->size);
 
     unsafe { mem::copy(self->mem + from, other->mem + other->at, size); }
 
@@ -364,13 +404,13 @@ export fn substr(Buffer+tail *self, usize from, usize mut size, Buffer+tail2 mut
 }
 
 /// split this buffer by token and copy the subbuffer into other
-export fn split(Buffer+tail *self, char token, usize mut *iterator, Buffer+tail2 mut new* other) -> bool
-    where   integrity(self, tail)
+export fn split(Buffer *self, char token, usize mut *iterator, Buffer mut new* other, usize tail2 = static(len(other->mem))) -> bool
+    where   integrity(self)
     where   tail2 > 0
-    model   integrity(self, tail)
-    model   integrity(other, tail2)
+    model   integrity(self)
+    model   integrity(other)
 {
-    make(other);
+    make(other, tail2);
 
     usize start = *iterator;
 
@@ -394,32 +434,3 @@ export fn split(Buffer+tail *self, char token, usize mut *iterator, Buffer+tail2
     return true;
 }
 
-/// make a buffer by copying raw bytes with given len
-export fn copy_bytes(Buffer+t new mut* self, u8* bytes, usize mut inlen)
-    where   t > 0
-    where   len(bytes) >= inlen
-    model   integrity(self, t)
-{
-    make(self);
-    self->append_bytes(bytes, inlen);
-}
-
-/// make a buffer by copying a slice
-export fn copy_slice(Buffer+t new mut* self, Slice slice)
-    where   t > 0
-    where   slicem::slice::integrity(&slice)
-    model   integrity(self, t)
-{
-    make(self);
-    self->append_slice(slice)
-}
-
-/// make a buffer by copying a c string
-export fn copy_cstr(Buffer+t new mut* self, char *s)
-    where   t > 0
-    where   nullterm(s)
-    model   integrity(self, t)
-{
-    make(self);
-    self->append_cstr(s)
-}

--- a/modules/buffer/tests/append.zz
+++ b/modules/buffer/tests/append.zz
@@ -16,7 +16,7 @@ test overflow{
 
 export fn main() -> int {
     buffer::Buffer+50 mut s = {0};
-    buffer::clear(&s);
+    buffer::make(&s);
 
     for (;;) {
         char mut * mut line = 0;

--- a/modules/buffer/tests/fgets.zz
+++ b/modules/buffer/tests/fgets.zz
@@ -20,7 +20,7 @@ test limiter {
 
 pub fn main() -> int {
     buffer::Buffer+10 mut s = {0};
-    buffer::clear(&s);
+    buffer::make(&s);
     if !buffer::fgets(&s, stdin) {
         return 2;
     }

--- a/modules/buffer/tests/format.zz
+++ b/modules/buffer/tests/format.zz
@@ -10,7 +10,7 @@ test blah {
 
 export fn main() -> int {
     buffer::Buffer+10 mut s;
-    buffer::clear(&s);
+    buffer::make(&s);
 
     buffer::append_cstr(&s, "hello");
     buffer::format(&s, "%d%d%d%d", 2, 3, 66,9);

--- a/modules/buffer/tests/from.zz
+++ b/modules/buffer/tests/from.zz
@@ -19,9 +19,9 @@ export fn main() -> int {
         static_attest(safe(line));
         static_attest(nullterm(line));
         static_attest(len(line) == (usize) nread);
-        new+50 mut s         = buffer::copy_bytes((u8 *)line, (usize)nread);
-        new+50 mut copy      = buffer::copy_slice(s.as_slice());
-        new+50 mut cstr_copy = buffer::copy_cstr(copy.cstr());
+        new+50 mut s         = buffer::from_bytes((u8 *)line, (usize)nread);
+        new+50 mut copy      = buffer::from_slice(s.as_slice());
+        new+50 mut cstr_copy = buffer::from_cstr(copy.cstr());
         free(line);
         printf("%.*s", s.slen(), s.mem);
         printf("%.*s", copy.slen(), copy.mem);

--- a/modules/buffer/tests/push.zz
+++ b/modules/buffer/tests/push.zz
@@ -5,7 +5,7 @@ using <stdlib.h>::{free};
 
 export fn main() -> int {
     buffer::Buffer+50 mut s = {0};
-    buffer::clear(&s);
+    buffer::make(&s);
 
     for (uint mut i =0; i < 100; i++) {
         buffer::push(&s, ' ');

--- a/modules/buffer/tests/split.zz
+++ b/modules/buffer/tests/split.zz
@@ -31,13 +31,13 @@ test test5 {
 export fn main() -> int {
 
     buffer::Buffer+100 mut a;
-    buffer::clear(&a);
+    buffer::make(&a);
     buffer::fgets(&a, stdin);
 
 
     usize mut iterator = 0;
     buffer::Buffer+100 mut part;
-    buffer::clear(&part);
+    buffer::make(&part);
     while (buffer::split(&a, ':', &iterator, &part)) {
         printf(">%.*s<\n", (int)part.at, part.mem);
         buffer::clear(&part);

--- a/modules/buffer/tests/substr.zz
+++ b/modules/buffer/tests/substr.zz
@@ -42,7 +42,7 @@ test t7{
 
 export fn main() -> int {
     buffer::Buffer+20 mut sub;
-    buffer::clear(&sub);
+    buffer::make(&sub);
 
     char mut * mut line = 0;
     usize mut l = 0;
@@ -54,7 +54,7 @@ export fn main() -> int {
 
 
     buffer::Buffer+20 mut s;
-    buffer::clear(&s);
+    buffer::make(&s);
 
     nread = as<int>(getline(&line, &l, stdin));
     if nread < 1 { return 1; }

--- a/modules/err/src/lib.zz
+++ b/modules/err/src/lib.zz
@@ -1,5 +1,5 @@
 using <stdio.h>::{printf, snprintf, vsnprintf, fprintf, vfprintf, stderr, FILE};
-using <string.h>::{memset, strncat, strlen};
+using <string.h>::{strncat, strlen};
 using <errno.h>::{errno, strerror};
 using <stdarg.h>::{va_list, va_start, va_end};
 using buffer;
@@ -22,23 +22,25 @@ export struct Err+ {
 };
 
 
-/// create a new error
-export fn make(Err+tail mut new*self)
-    model   checked(*self)
+/// create a new error with tail memory
+export fn make(Err mut new*self, usize tail = static(len(self->trace.mem)))
+    model checked(*self)
 {
     assert(tail > 0);
-    memset(self, 0, sizeof(Err));
-    buffer::clear(&(self->trace));
+    self->error     = 0;
+    self->system    = 0;
+    buffer::make(&self->trace, tail);
     static_attest(checked(*self));
 }
 
 /// ignore any previous errors and reset error state
-export fn ignore(Err+tail mut *self)
+export fn ignore(Err mut *self)
     model checked(*self)
 {
-    assert(tail > 0);
-    memset(self, 0, sizeof(Err));
-    buffer::clear(&self->trace);
+    self->error     = 0;
+    self->system    = 0;
+    static_attest(buffer::integrity(&self->trace));
+    self->trace.clear();
     static_attest(checked(*self));
 }
 
@@ -46,7 +48,7 @@ export fn ignore(Err+tail mut *self)
 ///
 /// returns true if error was set
 export  fn check(
-        Err+tail mut* self,
+        Err mut* self,
         char* callsite_source<file>      unsafe file,
         char* callsite_source<function>  unsafe scope,
         usize callsite_source<line>      line,
@@ -61,14 +63,14 @@ export  fn check(
     return false;
 }
 
-export fn backtrace(Err+tail mut* self, char * unsafe file, char * unsafe scope, usize line)
+export fn backtrace(Err mut* self, char * unsafe file, char * unsafe scope, usize line)
 {
-    static_attest(buffer::integrity(&self->trace, tail));
+    static_attest(buffer::integrity(&self->trace));
     self->trace.format("  - %s:%zu \t%s\n", file, line, scope);
 }
 
 export fn fail_with_errno(
-        Err+tail mut* self,
+        Err mut* self,
         char* callsite_source<file>      unsafe file,
         char* callsite_source<function>  unsafe scope,
         usize callsite_source<line>      line,
@@ -78,18 +80,18 @@ export fn fail_with_errno(
     where   nullterm(fmt)
     model   checked(*self)
 {
-    static_attest(buffer::integrity(&self->trace, tail));
+    static_attest(buffer::integrity(&self->trace));
     self->error  = SystemError;
     self->system = (int)errno;
 
-    if tail > 2 && self->trace.at > 0 {
+    if self->trace.size > 2 && self->trace.at > 0 {
         self->trace.push('\n');
     }
     self->trace.format("%s : ", strerror(errno));
 
     va_list mut vargs;
     va_start(vargs, fmt);
-    static_attest((self->trace).at < tail);
+    static_attest((self->trace).at < self->trace.size);
     self->trace.vformat(fmt, vargs);
     va_end(vargs);
 
@@ -99,7 +101,7 @@ export fn fail_with_errno(
 }
 
 export fn fail_with_system_error(
-        Err+tail mut* self,
+        Err mut* self,
         int merrno,
         char* callsite_source<file>      unsafe file,
         char* callsite_source<function>  unsafe scope,
@@ -110,18 +112,18 @@ export fn fail_with_system_error(
     where   nullterm(fmt)
     model   checked(*self)
 {
-    static_attest(buffer::integrity(&self->trace, tail));
+    static_attest(buffer::integrity(&self->trace));
     self->error  = SystemError;
     self->system = merrno;
 
-    if tail > 2 && self->trace.at > 0 {
+    if self->trace.size > 2 && self->trace.at > 0 {
         self->trace.push('\n');
     }
     self->trace.format("%s : ", strerror(merrno));
 
     va_list mut vargs;
     va_start(vargs, fmt);
-    static_attest((self->trace).at < tail);
+    static_attest((self->trace).at < self->trace.size);
     self->trace.vformat(fmt, vargs);
     va_end(vargs);
 
@@ -131,7 +133,7 @@ export fn fail_with_system_error(
 }
 
 export fn fail(
-        Err+tail mut* self,
+        Err mut* self,
         usize e,
         char* callsite_source<file>      unsafe file,
         char* callsite_source<function>  unsafe scope,
@@ -143,10 +145,10 @@ export fn fail(
     where   symbol(e)
     model   checked(*self)
 {
-    static_attest(buffer::integrity(&self->trace, tail));
+    static_attest(buffer::integrity(&self->trace));
     self->error = e;
 
-    if tail > 2 && self->trace.at > 0 {
+    if self->trace.size > 2 && self->trace.at > 0 {
         self->trace.push('\n');
     }
     if symbols::nameof_checked(self->error) == 0 {
@@ -166,7 +168,7 @@ export fn fail(
 }
 
 export fn abort(
-        Err+tail mut* self,
+        Err mut* self,
         char* callsite_source<file>      unsafe file,
         char* callsite_source<function>  unsafe scope,
         usize callsite_source<line>      line,
@@ -184,15 +186,15 @@ export fn abort(
     static_attest(checked(*self));
 }
 
-export fn elog(Err+tail * self)
+export fn elog(Err * self)
 {
-    static_attest(buffer::integrity(&self->trace, tail));
+    static_attest(buffer::integrity(&self->trace));
     log::error("%s\n", self->trace.cstr());
 }
 
-export fn eprintf(Err+tail * self, FILE mut * unsafe out)
+export fn eprintf(Err * self, FILE mut * unsafe out)
 {
-    static_attest(buffer::integrity(&self->trace, tail));
+    static_attest(buffer::integrity(&self->trace));
     fprintf(out, "%s\n", self->trace.cstr());
 }
 
@@ -202,7 +204,7 @@ export fn to_str(
     usize dest_len,
 )
 {
-    static_attest(buffer::integrity(&self->trace, et));
+    static_attest(buffer::integrity(&self->trace));
     snprintf(dest, dest_len, "%s\n", self->trace.cstr());
 }
 
@@ -290,7 +292,7 @@ export fn assert_safe(
 }
 
 export fn fail_with_win32(
-        Err+tail mut* self,
+        Err mut* self,
         char* callsite_source<file>      unsafe file,
         char* callsite_source<function>  unsafe scope,
         usize callsite_source<line>      line,
@@ -302,7 +304,7 @@ export fn fail_with_win32(
     model checked(*self)
     if #(os::defined(os::_WIN32))
 {
-    static_attest(buffer::integrity(&self->trace, tail));
+    static_attest(buffer::integrity(&self->trace));
     self->system = (int)os::GetLastError();
     self->error  = SystemError;
 
@@ -318,7 +320,7 @@ export fn fail_with_win32(
             self->system,
             os::MAKELANGID(os::LANG_NEUTRAL, os::SUBLANG_DEFAULT), 
             buf,
-            tail - as<usize>(strlen(self->trace.mem)),
+            self->trace.size - as<usize>(strlen(self->trace.mem)),
             0
             );
 

--- a/modules/json/src/des.zz
+++ b/modules/json/src/des.zz
@@ -4,118 +4,251 @@ using err;
 using log;
 using buffer;
 using slice;
+using json;
+
 
 pub macro impl()
 {
     new+10000 a = ast::from_macro();
 
-    if a.local.t == ast::DefType::Type {
+    static_attest(safe(a.local.v.dalias.alias.name));
+    static_attest(nullterm(a.local.v.dalias.alias.name));
+    if a.local.t == ast::DefType::Type && buffer::cstr_eq(a.local.v.dalias.alias.name, "::map::Map") {
 
-        slice::Slice mut vec_item = {0};
+        new+1000 mut map_key = buffer::make();
+        new+1000 mut map_val = buffer::make();
 
-        static_attest(nullterm(a.local.v.dalias.alias.name));
-        if buffer::cstr_eq(a.local.v.dalias.alias.name, "::vec::Vec") {
+        for let mut it = a.local.v.dalias.alias.params.iter(); it.next(); {
+            let expr = (ast::Expression*)it.val.mem;
+            err::assert_safe(expr);
+            if expr->t != ast::ExpressionType::Infix {
+                continue;
+            }
 
-            for let mut it = a.local.v.dalias.alias.params.iter(); it.next(); {
-                let expr = (ast::Expression*)it.val.mem;
-                err::assert_safe(expr);
-                if expr->t != ast::ExpressionType::Infix {
-                    continue;
-                }
-
-                let lhs = expr->v.infix.lhs;
-                err::assert_safe(lhs);
-                if lhs->t != ast::ExpressionType::Call {
-                    continue;
-                }
-                let name = lhs->v.call.name;
-                err::assert_safe(name);
-                if name->t != ast::ExpressionType::Name {
-                    continue;
-                }
-                if !name->v.string.eq_cstr("::vec::item") {
-                    continue;
-                }
-
+            let lhs = expr->v.infix.lhs;
+            err::assert_safe(lhs);
+            if lhs->t != ast::ExpressionType::Call {
+                continue;
+            }
+            let name = lhs->v.call.name;
+            err::assert_safe(name);
+            if name->t != ast::ExpressionType::Name {
+                continue;
+            }
+            static_attest(slice::slice::integrity(&name->v.string));
+            if name->v.string.eq_cstr("::map::key") {
                 let rhs = expr->v.infix.rhs;
                 err::assert_safe(rhs);
                 if rhs->t != ast::ExpressionType::Name {
                     continue;
                 }
-
-                vec_item = rhs->v.string;
-            }
-
-            if vec_item.size < 1 {
-                err::panic("derive on vec requires an attached smt expression of vec::item = type");
-            }
-
-            printf(r#"pub fn %s_json_des_impl_next(json::U *u, err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v, void mut*obj)
-                where err::checked(*e)
-                where nullterm(k)
-            {
-                vec::Vec[+0] mut * self = (vec::Vec[+0] mut *)obj;
-                static_attest(safe(self));
-                let pl = (pool::Pool mut *)u->user2;
-                static_attest(safe(pl));
-
-                if v.t != json::ValueType::Array {
-                    e->fail(err::InvalidArgument, "expected array for vec %s");
-                    return;
+                static_attest(slice::slice::integrity(&rhs->v.string));
+                map_key.append_slice(rhs->v.string);
+            } else if name->v.string.eq_cstr("::map::val") {
+                let rhs = expr->v.infix.rhs;
+                err::assert_safe(rhs);
+                if rhs->t != ast::ExpressionType::Name {
+                    continue;
                 }
-
-                static_attest(safe(v.string));
-                static_attest(nullterm(v.string));
-
-                self->make_with_pool(pl);
-
-                json::next(p,  e, json::U{
-                    it:    %s_json_des_impl_array,
-                    user1: obj,
-                    user2: u->user2,
-                });
-
-             }
-
-            "#, a.local.name, a.local.name, a.local.name);
-
-
-            printf(r#"pub fn %s_json_des_impl_array(json::U *u, err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
-                where err::checked(*e)
-                where nullterm(k)
-            {
-                vec::Vec mut * self = (vec::Vec mut *)u->user1;
-                static_attest(safe(self));
-                static_attest(vec::integrity(self) == true);
-
-                let pl = (pool::Pool mut *)u->user2;
-                static_attest(safe(pl));
-
-
-                if v.t == json::ValueType::Object {
-                    let m = (%.*s mut *)pl->malloc(sizeof(%.*s));
-                    if m == 0 {
-                        e->fail(err::OutOfTail, "cannot allocate %.*s from pool");
-                        return;
-                    }
-                    static_attest(safe(m));
-                    vec::push_b(self,m);
-                    %.*s_json_des_impl_next(u, e, p, k, v, (void mut*)m);
-                    if err::check(e) {
-                        return;
-                    }
-                }
+                static_attest(slice::slice::integrity(&rhs->v.string));
+                map_val.append_slice(rhs->v.string);
             }
-
-            "#, a.local.name,
-            vec_item.size, vec_item.mem, vec_item.size, vec_item.mem,  vec_item.size, vec_item.mem, vec_item.size, vec_item.mem);
-
-
-
         }
 
+        if map_key.slen()  == 0 {
+            err::panic("derive on map requires an attached smt expression of map::key = type");
+        }
+        if map_val.slen()  == 0 {
+            err::panic("derive on map requires an attached smt expression of map::val = type");
+        }
+
+        if !map_key.eq_cstr("char") {
+            err::panic("derive on map currently not supported for map::key = %s", map_key.cstr());
+        }
+
+        if !map_key.starts_with_cstr("::") {
+            new+1000 mut map_key2 = buffer::from_cstr("::json::des::");
+            map_key2.append_slice(map_key.as_slice());
+            map_key.clear();
+            map_key.append_slice(map_key2.as_slice());
+        }
+
+        if !map_val.starts_with_cstr("::") {
+            new+1000 mut map_val2 = buffer::from_cstr("::json::des::");
+            map_val2.append_slice(map_val.as_slice());
+            map_val.clear();
+            map_val.append_slice(map_val2.as_slice());
+        }
+
+
+        printf(r#"pub fn %s_json_des_impl_next(json::U *u, err::Err mut *e, json::Parser mut* p, char *k, json::Value v, void mut*obj)
+            where err::checked(*e)
+            where nullterm(k)
+        {
+            map::Map mut * self = (map::Map mut *)obj;
+            static_attest(safe(self));
+            let pl = (pool::Pool mut *)u->user2;
+            static_attest(safe(pl));
+
+            if v.t != json::ValueType::Object {
+                e->fail(err::InvalidArgument, "expected object for map %s");
+                return;
+            }
+
+            static_attest(safe(v.string));
+            static_attest(nullterm(v.string));
+
+            //TODO make earlier, so we can capture the tail
+            self->make_with_pool(pl, 0);
+
+            json::next(p,  e, json::U{
+                it:    %s_json_des_impl_map,
+                user1: obj,
+                user2: u->user2,
+            });
+
+         }
+
+        "#, a.local.name, a.local.name, a.local.name);
+
+        printf(r#"pub fn %s_json_des_impl_map(json::U *u, err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
+            where err::checked(*e)
+            where nullterm(k)
+        {
+            map::Map mut * self = (map::Map mut *)u->user1;
+            static_attest(safe(self));
+            //static_attest(map::integrity(self) == true);
+
+            let pl = (pool::Pool mut *)u->user2;
+            static_attest(safe(pl));
+
+            if v.t == json::ValueType::Object || json::ValueType::Integer {
+                let m = (%.*s mut *)pl->malloc(sizeof(%.*s));
+                if m == 0 {
+                    e->fail(err::OutOfTail, "cannot allocate %.*s from pool");
+                    return;
+                }
+                static_attest(safe(m));
+                map::insert_ob(self, k, m, buffer::strlen(k) + 1);
+                %.*s_json_des_impl_next(u, e, p, k, v, (void mut*)m);
+                if err::check(e) {
+                    return;
+                }
+            }
+        }
+
+        "#, a.local.name,
+        map_val.size, map_val.mem, map_val.size, map_val.mem,  map_val.size, map_val.mem, map_val.size, map_val.mem);
+
+    } else if a.local.t == ast::DefType::Type && buffer::cstr_eq(a.local.v.dalias.alias.name, "::vec::Vec") {
+
+        new+1000 mut vec_item = buffer::make();
+
+        for let mut it = a.local.v.dalias.alias.params.iter(); it.next(); {
+            let expr = (ast::Expression*)it.val.mem;
+            err::assert_safe(expr);
+            if expr->t != ast::ExpressionType::Infix {
+                continue;
+            }
+
+            let lhs = expr->v.infix.lhs;
+            err::assert_safe(lhs);
+            if lhs->t != ast::ExpressionType::Call {
+                continue;
+            }
+            let name = lhs->v.call.name;
+            err::assert_safe(name);
+            if name->t != ast::ExpressionType::Name {
+                continue;
+            }
+            static_attest(slice::slice::integrity(&name->v.string));
+            if !name->v.string.eq_cstr("::vec::item") {
+                continue;
+            }
+
+            let rhs = expr->v.infix.rhs;
+            err::assert_safe(rhs);
+            if rhs->t != ast::ExpressionType::Name {
+                continue;
+            }
+
+            static_attest(slice::slice::integrity(&rhs->v.string));
+            vec_item.append_slice(rhs->v.string);
+        }
+
+        if vec_item.slen()  == 0 {
+            err::panic("derive on vec requires an attached smt expression of vec::item = type");
+        }
+        if !vec_item.starts_with_cstr("::") {
+            new+1000 mut vec_item2 = buffer::from_cstr("::json::des::");
+            vec_item2.append_slice(vec_item.as_slice());
+            vec_item.clear();
+            vec_item.append_slice(vec_item2.as_slice());
+        }
+
+        printf(r#"pub fn %s_json_des_impl_next(json::U *u, err::Err mut *e, json::Parser mut* p, char *k, json::Value v, void mut*obj)
+            where err::checked(*e)
+            where nullterm(k)
+        {
+            vec::Vec mut * self = (vec::Vec mut *)obj;
+            static_attest(safe(self));
+            let pl = (pool::Pool mut *)u->user2;
+            static_attest(safe(pl));
+
+            if v.t != json::ValueType::Array {
+                e->fail(err::InvalidArgument, "expected array for vec %s");
+                return;
+            }
+
+            static_attest(safe(v.string));
+            static_attest(nullterm(v.string));
+
+            //TODO make earlier, so we can capture the tail
+            self->make_with_pool(pl, 0);
+
+            json::next(p,  e, json::U{
+                it:    %s_json_des_impl_array,
+                user1: obj,
+                user2: u->user2,
+            });
+
+         }
+
+        "#, a.local.name, a.local.name, a.local.name);
+
+
+        printf(r#"pub fn %s_json_des_impl_array(json::U *u, err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
+            where err::checked(*e)
+            where nullterm(k)
+        {
+            vec::Vec mut * self = (vec::Vec mut *)u->user1;
+            static_attest(safe(self));
+            static_attest(vec::integrity(self) == true);
+
+            let pl = (pool::Pool mut *)u->user2;
+            static_attest(safe(pl));
+
+
+            if v.t == json::ValueType::Object || json::ValueType::Integer {
+                let m = (%.*s mut *)pl->malloc(sizeof(%.*s));
+                if m == 0 {
+                    e->fail(err::OutOfTail, "cannot allocate %.*s from pool");
+                    return;
+                }
+                static_attest(safe(m));
+                vec::push_b(self,m);
+                %.*s_json_des_impl_next(u, e, p, k, v, (void mut*)m);
+                if err::check(e) {
+                    return;
+                }
+            }
+        }
+
+        "#, a.local.name,
+        vec_item.size, vec_item.mem, vec_item.size, vec_item.mem,  vec_item.size, vec_item.mem, vec_item.size, vec_item.mem);
+
     } else if a.local.t == ast::DefType::Enum {
-        printf(r#"pub fn %s_json_des_impl_next(json::U *u, err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v, void mut*obj)
+        printf(r#"pub fn %s_json_des_impl_next(json::U *u, err::Err mut *e, json::Parser mut* p, char *k, json::Value v, void mut*obj)
             where err::checked(*e)
             where nullterm(k)
         {
@@ -149,7 +282,7 @@ pub macro impl()
         }"#, a.local.name);
     } else if a.local.t == ast::DefType::Struct {
 
-        printf(r#"pub fn %s_json_des_impl_next(json::U *u, err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v, void mut*obj)
+        printf(r#"pub fn %s_json_des_impl_next(json::U *u, err::Err mut *e, json::Parser mut* p, char *k, json::Value v, void mut*obj)
             where err::checked(*e)
             where nullterm(k)
         {
@@ -162,7 +295,7 @@ pub macro impl()
             }
         }"#, a.local.name, a.local.name);
 
-        printf(r#"pub fn %s_json_des_impl_obj(json::U *u, err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+        printf(r#"pub fn %s_json_des_impl_obj(json::U *u, err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
             where err::checked(*e)
             where nullterm(k)
         {
@@ -227,7 +360,7 @@ pub macro impl()
                          fieldtype.cstr(),
                          field->name);
                 }
-            } else if fieldtype.eq_cstr("bool") || fieldtype.eq_cstr("Bool") {
+            } else if fieldtype.eq_cstr("bool") {
                 printf(r#"else if buffer::cstr_eq(k, "%s") && v.t == json::ValueType::Boolean {
                     if v.integer > 0 {
                         self->%s = true;
@@ -249,25 +382,11 @@ pub macro impl()
                 fieldtype.eq_cstr("i128") ||
                 fieldtype.eq_cstr("u128") ||
                 fieldtype.eq_cstr("isize") ||
-                fieldtype.eq_cstr("Usize") ||
-                fieldtype.eq_cstr("Int")  ||
-                fieldtype.eq_cstr("Uint") ||
-                fieldtype.eq_cstr("I8") ||
-                fieldtype.eq_cstr("U8") ||
-                fieldtype.eq_cstr("I16") ||
-                fieldtype.eq_cstr("U16") ||
-                fieldtype.eq_cstr("I32") ||
-                fieldtype.eq_cstr("U32") ||
-                fieldtype.eq_cstr("I64") ||
-                fieldtype.eq_cstr("U64") ||
-                fieldtype.eq_cstr("I128") ||
-                fieldtype.eq_cstr("U128") ||
-                fieldtype.eq_cstr("Isize") ||
-                fieldtype.eq_cstr("Usize")
+                fieldtype.eq_cstr("usize")
             {
                 printf(r#"else if buffer::cstr_eq(k, "%s") && v.t == json::ValueType::Integer {
-                    self->%s =  v.integer;
-                }"#, field->name, field->name);
+                    self->%s =  (%s)v.integer;
+                }"#, field->name, field->name, fieldtype.cstr());
             } else {
                 log::error("struct member '%s::%s' cannot be deserialized", a.local.name, field->name);
             }
@@ -275,8 +394,10 @@ pub macro impl()
 
         }
         printf("else {log::debug(\"json member '%%s' does not map to any field in struct '%s'\", k);} }", a.local.name);
+    } else if a.local.t == ast::DefType::Type{
+        err::panic("json des derive can not be used on type = %s", a.local.v.dalias.alias.name);
     } else {
-        err::panic("derive can only be applied to struct or enum");
+        err::panic("json des derive can not be used here (a.local.t = %d)", a.local.t);
     }
 
 }
@@ -299,3 +420,51 @@ pub macro use()
 }
 
 
+
+export type u64 = u64;
+export fn u64_json_des_impl_next(json::U *u, err::Err mut *e, json::Parser mut* p, char *k, json::Value v, void mut*obj)
+    where err::checked(*e)
+{
+    u64 mut *self = (u64 mut *)obj;
+    if v.t != json::ValueType::Integer {
+        e->fail(err::InvalidArgument, "expected integer");
+        return;
+    }
+    *self = (u64)v.integer;
+}
+
+export type u32 = u32;
+export fn u32_json_des_impl_next(json::U *u, err::Err mut *e, json::Parser mut* p, char *k, json::Value v, void mut*obj)
+    where err::checked(*e)
+{
+    u32 mut *self = (u32 mut *)obj;
+    if v.t != json::ValueType::Integer {
+        e->fail(err::InvalidArgument, "expected integer");
+        return;
+    }
+    *self = (u32)v.integer;
+}
+
+export type u16 = u16;
+export fn u16_json_des_impl_next(json::U *u, err::Err mut *e, json::Parser mut* p, char *k, json::Value v, void mut*obj)
+    where err::checked(*e)
+{
+    u16 mut *self = (u16 mut *)obj;
+    if v.t != json::ValueType::Integer {
+        e->fail(err::InvalidArgument, "expected integer");
+        return;
+    }
+    *self = (u16)v.integer;
+}
+
+export type u8 = u8;
+export fn u8_json_des_impl_next(json::U *u, err::Err mut *e, json::Parser mut* p, char *k, json::Value v, void mut*obj)
+    where err::checked(*e)
+{
+    u8 mut *self = (u8 mut *)obj;
+    if v.t != json::ValueType::Integer {
+        e->fail(err::InvalidArgument, "expected integer");
+        return;
+    }
+    *self = (u8)v.integer;
+}

--- a/modules/json/src/lib.zz
+++ b/modules/json/src/lib.zz
@@ -37,8 +37,8 @@ enum ParserState {
     PostVal,
 }
 
-export closure Iter      (U *u, err::Err+et mut *e, Parser+pt mut* p, char *k, Value v);
-export closure Pop       (U *u, err::Err+et mut *e, Parser+pt mut* p);
+export closure Iter      (U *u, err::Err mut *e, Parser mut* p, char *k, Value v);
+export closure Pop       (U *u, err::Err mut *e, Parser mut* p);
 
 export struct U {
     Iter    it;
@@ -67,20 +67,20 @@ export struct Parser+ {
     buffer::Buffer+ mut capture;
 }
 
-export fn parser(Parser+tail mut new*self, err::Err+et mut *e, U u)
+export fn parser(Parser mut new*self, err::Err mut *e, U u, usize tail = static(len(self->capture.mem)))
     where err::checked(*e)
     where tail > 1
     where safe(u.it)
 {
     memset(self, 0, sizeof(Parser));
-    buffer::clear(&self->capture);
+    buffer::make(&self->capture, tail);
 
     self->line  = 1;
 
     ((self->state)[0]).user   = u;
 }
 
-export fn next(Parser+tail mut*self, err::Err+et mut *e,  U u)
+export fn next(Parser mut*self, err::Err mut *e,  U u)
     where err::checked(*e)
     where safe(u.it)
 
@@ -100,13 +100,12 @@ export fn next(Parser+tail mut*self, err::Err+et mut *e,  U u)
     ((self->state)[self->depth]).user   = u;
 }
 
-export fn push(Parser+tail mut *self, err::Err+et mut *e, char *str, usize strlen)
+export fn push(Parser mut *self, err::Err mut *e, char *str, usize strlen)
     @solver("yices2")
     where err::checked(*e)
     where len(str) >= strlen
-    where tail > 2
 {
-    static_attest(buffer::integrity(&self->capture, tail));
+    static_attest(buffer::integrity(&self->capture));
     for (usize mut at = 0; at < strlen; at++) {
         self->col += 1;
 
@@ -209,12 +208,12 @@ export fn push(Parser+tail mut *self, err::Err+et mut *e, char *str, usize strle
     }
 }
 
-fn advance(Parser+tail mut *self, err::Err+et mut *e, char token)
+fn advance(Parser mut *self, err::Err mut *e, char token)
     where err::checked(*e)
-    where tail > 2
 {
     static_attest(self->depth  < len(self->state));
     ParserStack mut * mut stack = &((self->state)[self->depth]);
+    static_attest(buffer::integrity(&self->capture));
 
     switch stack->state {
         ParserState::Document => {

--- a/modules/json/src/main.zz
+++ b/modules/json/src/main.zz
@@ -5,7 +5,8 @@ using err;
 using buffer;
 using mem;
 using slice;
-using vec::{Vec, item};
+using vec;
+using map;
 using vec;
 
 
@@ -27,7 +28,14 @@ struct Window  @json::des::impl()
     bool open;
 }
 
-type WindowList @json::des::impl() = Vec[item = Window];
+struct Person @json::des::impl()
+{
+    u64 seat;
+}
+
+type WindowList @json::des::impl() = vec::Vec[vec::item = Window];
+type IntList    @json::des::impl() = vec::Vec[vec::item = u64];
+type PeopleMap  @json::des::impl() = map::Map[map::key  = char, map::val = Person];
 
 struct Car @json::des::impl()
 {
@@ -36,6 +44,8 @@ struct Car @json::des::impl()
     Engine      engine;
     Window*     sunroof;
     WindowList  windows;
+    IntList     ints;
+    PeopleMap   people;
 }
 
 
@@ -67,16 +77,21 @@ pub fn main() {
             "open": true
         },
         "windows": [
-        {
-            "open": true
-        },
-        {
-            "open": false
-        },
-        {
-            "open": true
-        },
-        ]
+            {
+                "open": true
+            },
+            {
+                "open": false
+            },
+            {
+                "open": true
+            },
+        ],
+        "ints": [1,2,3,4,4,5,6,7,7],
+        "people": {
+            "mum" :     { "seat": 1},
+            "the cat":      { "seat": 2},
+        }
     }"#, &p);
     e.abort();
 
@@ -93,5 +108,14 @@ pub fn main() {
         let window = (Window *)iter.val.mem;
         err::assert_safe(window);
         log::info("car.windows[].open = %d", window->open);
+    }
+    for let mut iter = vec::iter(&car.ints); iter.next(); {
+        u64 v = unsafe<u64>(*(u64 *)iter.val.mem);
+        log::info("car.ints[] = %d", v);
+    }
+    for let mut iter = map::keys(&car.people); iter.next(); {
+        Person *v = (Person*)map::get(&car.people, iter.key.mem, iter.key.size);
+        err::assert_safe(v);
+        log::info("car.people[%s].seat = %d", iter.key.mem, v->seat);
     }
 }

--- a/modules/json/tests/b.zz
+++ b/modules/json/tests/b.zz
@@ -23,13 +23,13 @@ struct Vehicle {
 
 symbol InvalidValue;
 
-fn deserialize_charge(json::U *u, err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn deserialize_charge(json::U *u, err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
 {
     printf("charge.>%s< == >%s< %u, %d [%zu]\n", k, v.string, v.t, v.integer, v.index);
 }
 
-fn deserialize_engine(json::U *u, err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn deserialize_engine(json::U *u, err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
     where nullterm(k)
     where nullterm(v.string)
@@ -56,7 +56,7 @@ fn deserialize_engine(json::U *u, err::Err+et mut *e, json::Parser+pt mut* p, ch
     }
 }
 
-fn deserialize_vehicle(json::U *u, err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn deserialize_vehicle(json::U *u, err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
     where nullterm(k)
 {

--- a/modules/json/tests/print.zz
+++ b/modules/json/tests/print.zz
@@ -122,7 +122,7 @@ test _object_in_array {
 
 
 
-fn pop(json::U *u, err::Err+et mut *e, json::Parser+pt mut* p)
+fn pop(json::U *u, err::Err mut *e, json::Parser mut* p)
     where err::checked(*e)
 {
     char mut *k = u->user1;
@@ -133,7 +133,7 @@ fn pop(json::U *u, err::Err+et mut *e, json::Parser+pt mut* p)
     printf("</%s>\n", k);
     free(k);
 }
-fn pretty(json::U *u, err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn pretty(json::U *u, err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
 {
     usize depth = u->user2;

--- a/modules/json/tests/turbo.zz
+++ b/modules/json/tests/turbo.zz
@@ -11,7 +11,7 @@ test test123  {
 }
 
 
-fn pretty(json::U *u, err::Err+et mut *e, json::Parser+pt mut* p, char *k, json::Value v)
+fn pretty(json::U *u, err::Err mut *e, json::Parser mut* p, char *k, json::Value v)
     where err::checked(*e)
 {
     let depth = (usize)u->user2;

--- a/modules/json/zz.toml
+++ b/modules/json/zz.toml
@@ -11,6 +11,7 @@ lflags = []
 err  = "1"
 pool = "1"
 ast  = "1"
+map  = "1"
 
 [variants]
 default = []

--- a/modules/list/src/lib.zz
+++ b/modules/list/src/lib.zz
@@ -20,9 +20,9 @@ export struct List+ {
 /// create a new list
 ///
 ///     new+1000 l = list::make();
-export fn make(List+lt mut new* self) {
+export fn make(List mut new* self, usize lt = static(len(self->pool.pmem))) {
     mem::zero(self);
-    self->pool.make(sizeof(Item));
+    self->pool.make(sizeof(Item), lt);
 }
 
 /// create a new list with an additional pool
@@ -33,9 +33,9 @@ export fn make(List+lt mut new* self) {
 ///     new+1000 p = pool::make(8);
 ///     new+0 l = list::make_with_pool(&p);
 ///
-export fn make_with_pool(List+lt mut new* self, pool::Pool mut * pool) {
+export fn make_with_pool(List mut new* self, pool::Pool mut * pool, usize lt = static(len(self->pool.pmem))) {
     mem::zero(self);
-    self->pool.make(sizeof(Item));
+    self->pool.make(sizeof(Item), lt);
     self->pool.extra = pool;
 }
 

--- a/modules/map/src/lib.zz
+++ b/modules/map/src/lib.zz
@@ -9,16 +9,18 @@ using <assert.h>::{assert};
 
 inline using "siphash.h" as  siphash;
 
+export theory key(Map self) type;
+export theory val(Map self) type;
 
 //TODO should not export?
 export struct Node {
     u64     hash;
     Node    mut * mut next;
 
-    bool key_owned;
-    bool val_owned;
-    slice::Slice key;
-    slice::Slice val;
+    bool k_owned;
+    bool v_owned;
+    slice::Slice k;
+    slice::Slice v;
 }
 
 export struct Bucket {
@@ -33,11 +35,14 @@ export struct Map+ {
 }
 
 /// create a new map
-export fn make(Map+tt mut new* self) {
+export fn make(Map mut new* self, usize tt = static(len(self->p.pmem))) {
     memset(self, 0, sizeof(Map));
 
-    self->p.make(sizeof(Bucket));
+    self->p.make(sizeof(Bucket), tt);
     self->buckets_reserved = tt/unsafe<usize>(sizeof(Bucket))/10;
+    if self->buckets_reserved < 16 {
+        self->buckets_reserved = 16;
+    }
     self->buckets = self->p.malloc(unsafe<usize>(sizeof(Bucket)) * self->buckets_reserved);
     err::assert_safe(self->buckets);
 }
@@ -49,12 +54,15 @@ export fn make(Map+tt mut new* self) {
 ///
 ///     new+1000 p = pool::make(8);
 ///     new+0 l = map::make_with_pool(&p);
-export fn make_with_pool(Map+tt mut new* self, pool::Pool mut *extra) {
+export fn make_with_pool(Map mut new* self, pool::Pool mut *extra, usize tt = static(len(self->p.pmem))) {
     memset(self, 0, sizeof(Map));
 
-    self->p.make(sizeof(Bucket));
+    self->p.make(sizeof(Bucket), tt);
     self->p.extra = extra;
     self->buckets_reserved = tt/unsafe<usize>(sizeof(Bucket))/10;
+    if self->buckets_reserved < 16 {
+        self->buckets_reserved = 16;
+    }
     self->buckets = self->p.malloc(unsafe<usize>(sizeof(Bucket)) * self->buckets_reserved);
     err::assert_safe(self->buckets);
 }
@@ -70,18 +78,27 @@ export fn count(Map * self) -> usize
 /// the borrowed references must be valid for the lifetime of the map
 ///
 /// returns false if there's not enough memory to store the key
-export fn insert_bb(Map mut* self, void+kt * key, void+vt * val) -> bool
+export fn insert_bb(
+    Map mut* self, void * k, void * v,
+    usize kt = static(len(k), 1) * sizeof(*k),
+    usize vt = static(len(v), 1) * sizeof(*v)
+) -> bool
+    where !constrained(key(*self)) || typeof(*k) == key(*self)
+    where !constrained(val(*self)) || typeof(*v) == val(*self)
 {
+    static_attest(len(k) == kt);
+    static_attest(len(v) == vt);
+
     Node mut * nn = self->p.malloc(unsafe<usize>(sizeof(Node)));
     if nn == 0 {
         return false;
     }
     static_attest(safe(nn));
-    nn->key = slice::slice::Slice{mem: key, size: kt};
-    nn->key_owned = false;
-    nn->val = slice::slice::Slice{mem: val, size: vt};
-    nn->val_owned = false;
-    nn->hash = hash(nn->key);
+    nn->k = slice::slice::Slice{mem: k, size: kt};
+    nn->k_owned = false;
+    nn->v = slice::slice::Slice{mem: v, size: vt};
+    nn->v_owned = false;
+    nn->hash = hash(nn->k);
 
     return self->i_insert(nn);
 }
@@ -91,28 +108,37 @@ export fn insert_bb(Map mut* self, void+kt * key, void+vt * val) -> bool
 /// the borrowed value reference must be valid for the lifetime of the map
 ///
 /// returns false if there's not enough memory to store the key
-export fn insert_ob(Map mut* self, void+kt * key, void+vt * val) -> bool
+export fn insert_ob(
+    Map mut* self, void * k, void * v,
+    usize kt = static(len(k), 1) * sizeof(*k),
+    usize vt = static(len(v), 1) * sizeof(*v)
+) -> bool
+    where !constrained(key(*self)) || typeof(*k) == key(*self)
+    where !constrained(val(*self)) || typeof(*v) == val(*self)
 {
-    void mut * owned_key = self->p.malloc(kt);
-    if owned_key == 0 {
+    static_attest(len(k) == kt);
+    static_attest(len(v) == vt);
+
+    void mut * owned_k = self->p.malloc(kt);
+    if owned_k == 0 {
         return false;
     }
-    static_attest(safe(owned_key));
-    static_attest(len(key) == kt);
-    static_attest(len(owned_key) == kt);
-    mem::copy(key, owned_key, kt);
+    static_attest(safe(owned_k));
+    static_attest(len(k) == kt);
+    static_attest(len(owned_k) == kt);
+    mem::copy(k, owned_k, kt);
 
     Node mut * nn = self->p.malloc(unsafe<usize>(sizeof(Node)));
     if nn == 0 {
-        self->p.free(owned_key);
+        self->p.free(owned_k);
         return false;
     }
     static_attest(safe(nn));
-    nn->key = slice::slice::Slice{mem: owned_key, size: kt};
-    nn->key_owned = true;
-    nn->val = slice::slice::Slice{mem: val, size: vt};
-    nn->val_owned = false;
-    nn->hash = hash(nn->key);
+    nn->k = slice::slice::Slice{mem: owned_k, size: kt};
+    nn->k_owned = true;
+    nn->v = slice::slice::Slice{mem: v, size: vt};
+    nn->v_owned = false;
+    nn->hash = hash(nn->k);
 
     return self->i_insert(nn);
 }
@@ -120,52 +146,61 @@ export fn insert_ob(Map mut* self, void+kt * key, void+vt * val) -> bool
 /// insert owned key and owned value
 ///
 /// both key and value are memcpy'd into the maps pool.
-/// note that if the objects hold circular refferences, they are now invalid.
+/// note that if the objects hold circular refferences, they are now invalid
 ///
 /// returns false if there's not enough memory to store the kv
-export fn insert_oo(Map mut* self, void+kt * key, void+vt * val) -> bool {
+export fn insert_oo(
+    Map mut* self, void * k, void * v,
+    usize kt = static(len(k), 1) * sizeof(*k),
+    usize vt = static(len(v), 1) * sizeof(*v)
+) -> bool
+    where !constrained(key(*self)) || typeof(*k) == key(*self)
+    where !constrained(val(*self)) || typeof(*v) == val(*self)
+{
+    static_attest(len(k) == kt);
+    static_attest(len(v) == vt);
 
-    void mut * owned_key = self->p.malloc(kt);
-    if owned_key == 0 {
+    void mut * owned_k = self->p.malloc(kt);
+    if owned_k == 0 {
         return false;
     }
-    static_attest(safe(owned_key));
-    static_attest(len(key) == kt);
-    static_attest(len(owned_key) == kt);
-    mem::copy(key, owned_key, kt);
+    static_attest(safe(owned_k));
+    static_attest(len(k) == kt);
+    static_attest(len(owned_k) == kt);
+    mem::copy(k, owned_k, kt);
 
-    void mut * owned_val = self->p.malloc(vt);
-    if owned_val == 0 {
+    void mut * owned_v = self->p.malloc(vt);
+    if owned_v == 0 {
         return false;
     }
-    static_attest(safe(owned_val));
-    static_attest(len(val) == vt);
-    static_attest(len(owned_val) == vt);
-    mem::copy(val, owned_val, vt);
+    static_attest(safe(owned_v));
+    static_attest(len(v) == vt);
+    static_attest(len(owned_v) == vt);
+    mem::copy(v, owned_v, vt);
 
     Node mut * nn = self->p.malloc(unsafe<usize>(sizeof(Node)));
     if nn == 0 {
-        self->p.free(owned_key);
-        self->p.free(owned_val);
+        self->p.free(owned_k);
+        self->p.free(owned_v);
         return false;
     }
     static_attest(safe(nn));
-    nn->key = slice::slice::Slice{mem: owned_key, size: kt};
-    nn->key_owned = true;
-    nn->val = slice::slice::Slice{mem: owned_val, size: vt};
-    nn->val_owned = true;
+    nn->k = slice::slice::Slice{mem: owned_k, size: kt};
+    nn->k_owned = true;
+    nn->v = slice::slice::Slice{mem: owned_v, size: vt};
+    nn->v_owned = true;
 
-    nn->hash = hash(nn->key);
+    nn->hash = hash(nn->k);
 
     return self->i_insert(nn);
 }
 
 
 fn i_insert(Map mut* self, Node mut *node) -> bool
-    where slice::slice::integrity(&node->key)
-    where slice::slice::integrity(&node->val)
+    where slice::slice::integrity(&node->k)
+    where slice::slice::integrity(&node->v)
 {
-    self->remove_slk(node->key, node->hash);
+    self->remove_slk(node->k, node->hash);
 
     usize index = (usize)node->hash % self->buckets_reserved;
     static_attest(index < len(self->buckets));
@@ -191,60 +226,6 @@ fn i_insert(Map mut* self, Node mut *node) -> bool
     return false;
 }
 
-
-
-/// copy out a value for the key
-///
-/// returns true if found and the stored value fits exactly into the copy target
-/// otherwise returns falseS
-///
-/// example:
-///     MyThing x = {0};
-///     if !map.copy("bob", &x) { err::panic("no such key"); }
-///
-export fn copy(Map mut* self, void+kt * key, void+vt mut *val) -> bool
-{
-    return copy_sl(self, slice::slice::Slice{mem:key, size: kt}, val);
-}
-
-fn copy_sl(Map mut* self, slice::slice::Slice key, void+vt mut *val) -> bool
-    where slice::slice::integrity(&key)
-{
-    let hk = hash(key);
-
-    usize index = (usize)hk % self->buckets_reserved;
-    static_attest(index < len(self->buckets));
-    Bucket mut* bucket = self->buckets + index;
-
-    if bucket->root == 0 {
-        return 0;
-    }
-
-    Node mut * mut no = bucket->root;
-    for (;;) {
-        static_attest(safe(no));
-        static_attest(slice::slice::integrity(&no->key));
-        static_attest(slice::slice::integrity(&no->val));
-
-        if no->hash == hk && no->key.eq(key) {
-            if no->val.size != vt {
-                return false;
-            }
-            mem::copy(no->val.mem, val, vt);
-            return true;
-        }
-
-        if no->next == 0 {
-            return 0;
-        }
-        no = no->next;
-    }
-
-    return 0;
-}
-
-
-
 /// returns a pointer to a borrowed value for the key
 /// or 0 if no such key exists
 ///
@@ -252,9 +233,11 @@ fn copy_sl(Map mut* self, slice::slice::Slice key, void+vt mut *val) -> bool
 ///     let x = (MyThing *x)map.borrow("bob");
 ///     if x == 0 { err::panic("no such key"); }
 ///
-export fn borrow(Map mut* self, void+kt * key) -> void mut *
+export fn get(Map mut* self, void * k, usize kt = static(len(k), 1) * sizeof(*k)) void mut *
+    where !constrained(key(*self)) || typeof(*k) == key(*self)
 {
-    return (void mut*)(borrow_slice(self, key).mem);
+    let r = (void mut*)(get_slice(self, k, kt).mem);
+    return r;
 }
 
 /// returns a slice to a borrowed value for the key
@@ -264,10 +247,12 @@ export fn borrow(Map mut* self, void+kt * key) -> void mut *
 ///     let x = map.borrow_slice("bob");
 ///     if x.mem == 0 { err::panic("no such key"); }
 ///
-export fn borrow_slice(Map mut* self, void+kt * key_) -> slice::slice::Slice
+export fn get_slice(Map mut* self, void * k, usize kt = static(len(k), 1) * sizeof(*k)) slice::slice::Slice
 {
-    let keyx = slice::slice::Slice{mem:key_, size: kt};
-    let hk = hash(keyx);
+    static_attest(len(k) == kt);
+
+    let kx = slice::slice::Slice{mem:k, size: kt};
+    let hk = hash(kx);
 
     usize index = (usize)hk % self->buckets_reserved;
     static_attest(index < len(self->buckets));
@@ -280,10 +265,10 @@ export fn borrow_slice(Map mut* self, void+kt * key_) -> slice::slice::Slice
     Node mut * mut no = bucket->root;
     for (;;) {
         static_attest(safe(no));
-        static_attest(slice::slice::integrity(&no->key));
+        static_attest(slice::slice::integrity(&no->k));
 
-        if no->hash == hk && no->key.eq(keyx) {
-            return no->val;
+        if no->hash == hk && no->k.eq(kx) {
+            return no->v;
         }
 
         if no->next == 0 {
@@ -298,24 +283,24 @@ export fn borrow_slice(Map mut* self, void+kt * key_) -> slice::slice::Slice
 /// remove an entry by object key
 ///
 /// returns true if entry was found, false otherwise
-export fn remove(Map mut* self, void+kt * key) -> bool
+export fn remove(Map mut* self, void * k, usize kt = sizeof(*k)) -> bool
 {
-    static_attest(len(key) == kt);
-    return remove_sl(self, slice::slice::Slice{mem:key, size: kt});
+    static_attest(len(k) == kt);
+    return remove_sl(self, slice::slice::Slice{mem:k, size: kt});
 }
 
-fn remove_sl(Map mut* self, slice::slice::Slice key) -> bool
-    where slice::slice::integrity(&key)
+fn remove_sl(Map mut* self, slice::slice::Slice k) -> bool
+    where slice::slice::integrity(&k)
 {
-    let hk = hash(key);
-    return remove_slk(self, key, hk);
+    let hk = hash(k);
+    return remove_slk(self, k, hk);
 }
 
 /// remove entry by prehashed slice key
 ///
 /// returns true if entry was found, false otherwise
-fn remove_slk(Map mut* self, slice::slice::Slice key, u64 ha) -> bool
-    where slice::slice::integrity(&key)
+fn remove_slk(Map mut* self, slice::slice::Slice k, u64 ha) -> bool
+    where slice::slice::integrity(&k)
 {
     usize index = (usize)ha % self->buckets_reserved;
     static_attest(index < len(self->buckets));
@@ -327,9 +312,9 @@ fn remove_slk(Map mut* self, slice::slice::Slice key, u64 ha) -> bool
 
     Node mut * mut no = bucket->root;
     static_attest(safe(no));
-    static_attest(slice::slice::integrity(&no->key));
-    static_attest(slice::slice::integrity(&no->val));
-    if no->hash == ha && no->key.eq(key) {
+    static_attest(slice::slice::integrity(&no->k));
+    static_attest(slice::slice::integrity(&no->v));
+    if no->hash == ha && no->k.eq(k) {
         self->i_dealloc(no);
         self->item_count -= 1;
         bucket->root = 0;
@@ -342,9 +327,9 @@ fn remove_slk(Map mut* self, slice::slice::Slice key, u64 ha) -> bool
             return false;
         }
         static_attest(safe(no->next));
-        static_attest(slice::slice::integrity(&no->next->key));
-        static_attest(slice::slice::integrity(&no->next->val));
-        if no->next->hash == ha && no->next->key.eq(key) {
+        static_attest(slice::slice::integrity(&no->next->k));
+        static_attest(slice::slice::integrity(&no->next->v));
+        if no->next->hash == ha && no->next->k.eq(k) {
 
             let tt = no->next;
             no->next = tt->next;
@@ -362,7 +347,7 @@ fn remove_slk(Map mut* self, slice::slice::Slice key, u64 ha) -> bool
 export struct Keys{
     Map mut* m;
     usize bucket;
-    Node *next;
+    Node *inext;
     slice::Slice mut key;
 }
 
@@ -370,7 +355,7 @@ export struct Keys{
 ///
 /// example:
 ///     for (let it = map.keys(); it.next(); ) {
-///         println("%.*s", it.key.size, it.key.mem);
+///         println("%.*s", it.k.size, it.k.mem);
 ///     }
 ///
 export fn keys(Map mut* self) -> Keys
@@ -387,12 +372,12 @@ export fn next(Keys mut* self) -> bool
     model slice::slice::integrity(&self->key)
 {
     static_attest(safe(self->m));
-    if self->next != 0 {
-        static_attest(safe(self->next));
-        self->next = self->next->next;
-        if self->next != 0 {
-            static_attest(safe(self->next));
-            self->key  = self->next->key;
+    if self->inext != 0 {
+        static_attest(safe(self->inext));
+        self->inext = self->inext->next;
+        if self->inext != 0 {
+            static_attest(safe(self->inext));
+            self->key  = self->inext->k;
             static_attest(slice::slice::integrity(&self->key));
             return true;
         } else {
@@ -408,11 +393,11 @@ export fn next(Keys mut* self) -> bool
         }
 
         static_attest(len(self->m->buckets) > self->bucket);
-        self->next = self->m->buckets[self->bucket].root;
+        self->inext = self->m->buckets[self->bucket].root;
 
-        if self->next != 0 {
-            static_attest(safe(self->next));
-            self->key  = self->next->key;
+        if self->inext != 0 {
+            static_attest(safe(self->inext));
+            self->key  = self->inext->k;
             return true;
         }
         self->bucket += 1;
@@ -425,7 +410,7 @@ export fn next(Keys mut* self) -> bool
 
 
 
-static u8 siphashk[] = {1,2,3,4,6,7,8,9,0,1,2,3,4,5,6};
+static u8 siphashk[] = {1,2,3,4,6,7,8,9,0,1,2,3,4,5,6,7};
 fn hash(slice::Slice sl) -> u64
 {
     u64 mut out = 0;
@@ -438,15 +423,15 @@ fn hash(slice::Slice sl) -> u64
 }
 
 fn i_dealloc(Map mut* self, Node mut *node)
-    where slice::slice::integrity(&node->key)
-    where slice::slice::integrity(&node->val)
+    where slice::slice::integrity(&node->k)
+    where slice::slice::integrity(&node->v)
 {
-    if node->key_owned {
-        static_attest(pool::member(node->key.mem, &self->p));
-        self->p.free(node->key.mem);
+    if node->k_owned {
+        static_attest(pool::member(node->k.mem, &self->p));
+        self->p.free(node->k.mem);
     }
-    if node->val_owned {
-        static_attest(pool::member(node->val.mem, &self->p));
-        self->p.free(node->val.mem);
+    if node->v_owned {
+        static_attest(pool::member(node->v.mem, &self->p));
+        self->p.free(node->v.mem);
     }
 }

--- a/modules/map/src/main.zz
+++ b/modules/map/src/main.zz
@@ -12,57 +12,88 @@ struct A+ {
 
 pub fn main() -> int {
 
-    new+1000 t = map::make();
-    err::assert(t.insert_oo("bob", "uncle"));
-    err::assert(t.count() == 1);
-    err::assert(t.insert_oo("bob", "uncle"));
-    err::assert(t.insert_oo("doop", "helooooooooo world blabla hurp durp lirum larum ipsum derpum"));
-    err::assert(t.count() == 2);
 
-    let vv = (char*)t.borrow("doop");
-    log::info("%s", vv);
+    new[map::key = char, map::val = char, +1000] smap = map::make();
 
-    err::assert(t.count() == 2);
-    err::assert(t.remove("doop"));
-    err::assert(!t.remove("doop"));
-    err::assert(t.count() == 1);
+    smap.insert_oo("bob", "uncle");
+    err::assert(smap.count() == 1);
 
-    err::assert(t.insert_oo("bob", "uncle"));
-    err::assert(t.insert_oo("bob", slice::slice::Slice{mem: (u8*)"uncle sam", size: 6}));
-    err::assert(t.insert_bb("bob", slice::slice::Slice{mem: (u8*)"uncle sam", size: 6}));
-    err::assert(t.count() == 1);
+    log::info("%s", smap.get("bob"));
 
-    let vv2 = (char*)t.borrow("bob");
-    log::info("%s", vv2);
 
-    A+1000 mut a;
+
+
+
+    new[map::key = char, +1000] amap = map::make();
+
+    A+1000 mut a = {0};
     a.b.make();
     a.b.append_cstr("blargh");
     a.b.append_cstr(" borp");
 
     // too large to own
-    err::assert(!t.insert_oo("bob", &a));
+    err::assert(!amap.insert_oo("bob", &a));
     // ok to borrow
-    err::assert(t.insert_ob("bob", &a));
+    err::assert(amap.insert_ob("bob", &a));
+
+    err::assert(amap.count() == 1);
+
+
+    let gimmeback = (A*)amap.get("bob");
+    err::assert_safe(gimmeback);
+    static_attest(buffer::integrity(&gimmeback->b));
+    log::info("%s", gimmeback->b.cstr());
+
+
+
+
+    /*
+
+    err::assert(t.insert_oo(bob.mem, uncle.mem));
+    err::assert(t.count() == 1);
+    err::assert(t.insert_oo(bob.mem, uncle.mem));
+    err::assert(t.insert_oo(doop.mem, text.mem));
+    err::assert(t.count() == 2);
+
+    let vv = (char*)t.borrow(doop.mem);
+    log::info("%s", vv);
+
+    err::assert(t.count() == 2);
+    err::assert(t.remove(doop.mem));
+    err::assert(!t.remove(doop.mem));
+    err::assert(t.count() == 1);
+
+    err::assert(t.insert_oo(bob.mem, uncle.mem));
+    err::assert(t.insert_oo(bob.mem, uncle.mem));
+    err::assert(t.insert_bb(bob.mem, uncle.mem));
+    err::assert(t.count() == 1);
+
+    let vv2 = (char*)t.borrow(bob.mem);
+    log::info("%s", vv2);
+
+
+    // too large to own
+    err::assert(!t.insert_oo(bob.mem, &a));
+    // ok to borrow
+    err::assert(t.insert_ob(bob.mem, &a));
 
     err::assert(t.count() == 1);
 
-    A+1000 mut ac;
-    err::assert(t.copy("bob", &ac));
 
-    log::info("%s", ac.b.mem);
-
-    err::assert(t.insert_oo("bob",  "uncle"));
-    err::assert(t.insert_oo("boba", "unclina"));
-    err::assert(t.insert_oo("derp", "ughlinor"));
+    err::assert(t.insert_oo(bob.mem,  uncle.mem));
+    err::assert(t.insert_oo(CS("bob").mem, CS("unclina").mem);
+    err::assert(t.insert_oo(CS("derp"), "ughlinor"));
     err::assert(t.insert_oo("foo", "baz bar biggest borp"));
     err::assert(t.remove("boba"));
     err::assert(t.count() == 3);
 
     for(let mut it = t.keys(); map::next(&it);) {
-        let vv2 = (char*)t.borrow(it.key);
-        log::info(" - %s = %s", (char*)it.key.mem, vv2);
+        let vv2 = (char*)t.borrow(it.k.mem);
+        log::info(" - %s = %s", (char*)it.k.mem, vv2);
     }
+
+
+    */
 
     return 0;
 }

--- a/modules/net/src/address.zz
+++ b/modules/net/src/address.zz
@@ -50,8 +50,8 @@ export fn valid(Address * self) -> bool {
 ///  - [2001:4860:4860::8888]:9000
 ///  - [10f::]:9000
 ///  - 2003:fb:ef05:6000:6000:9a6a:dd59:1234
-export fn from_buffer(Address mut new * self, buffer::Buffer+st *s)
-    where buffer::integrity(s, st)
+export fn from_buffer(Address mut new * self, buffer::Buffer *s)
+    where buffer::integrity(s)
 {
     from_str(self, s->mem, s->at);
 }
@@ -245,10 +245,9 @@ export fn from_str_ipv4(Address mut new* self, char *s, usize slen) -> bool
 }
 
 /// append ip address to buffer, excluding port
-export fn ip_to_buffer(Address * self, buffer::Buffer+st mut*to)
-    where   buffer::integrity(to,st)
-    model   buffer::integrity(to,st)
-    where   st>2
+export fn ip_to_buffer(Address * self, buffer::Buffer mut*to)
+    where   buffer::integrity(to)
+    model   buffer::integrity(to)
 {
     OsAddress mut *osa = (OsAddress mut *)self->os;
 
@@ -323,10 +322,9 @@ export fn ip_to_buffer(Address * self, buffer::Buffer+st mut*to)
 }
 
 /// append ip address to buffer, including port
-export fn to_buffer(Address * self, buffer::Buffer+st mut*to)
-    where   buffer::integrity(to,st)
-    model   buffer::integrity(to,st)
-    where   st>2
+export fn to_buffer(Address * self, buffer::Buffer mut*to)
+    where   buffer::integrity(to)
+    model   buffer::integrity(to)
 {
     OsAddress mut *osa = (OsAddress mut *)self->os;
 

--- a/modules/pool/src/lib.zz
+++ b/modules/pool/src/lib.zz
@@ -38,7 +38,7 @@ export struct Pool+ {
 /// mypool.alloc(); // get a single block of 10 bytes
 /// mypool.malloc(22); // get a continuous memory span of 22 bytes (less efficient)
 ///
-export fn make(Pool+pt mut new*self, usize mut blocksize)
+export fn make(Pool mut new*self, usize mut blocksize, usize pt = static(len(self->pmem)))
     model continuous(*self)
 {
     mem::zero(self);

--- a/modules/slice/src/mut_slice.zz
+++ b/modules/slice/src/mut_slice.zz
@@ -20,7 +20,7 @@ pub theory integrity(MutSlice mut*self) -> bool (
 export fn make(MutSlice new mut*self, u8 mut*mem, usize size, usize mut *at)
     where len(mem) >= size
     where safe(at)
-    where *at < size
+    where *at <= size
     model integrity(self)
     model len(mem) == len(self->mem)
     model *at == *self->at

--- a/modules/slice/src/slice.zz
+++ b/modules/slice/src/slice.zz
@@ -59,6 +59,18 @@ export fn make(Slice mut new *self, u8 *mem, usize size)
     static_attest(len(self->mem) == self->size);
 }
 
+export fn from_cstr(char *cs) Slice
+    where nullterm(cs)
+    model integrity(&return)
+{
+    let r = Slice {
+        size : (usize)c_string::strlen(cs) + 1,
+        mem  :  (u8*)cs,
+    };
+    static_attest(integrity(&r));
+    return r;
+}
+
 /// split this slice by a token
 export fn split(Slice *self, u8 token, usize mut *iterator,  Slice new mut *other) -> bool
     where   integrity(self)

--- a/modules/toml/src/lib.zz
+++ b/modules/toml/src/lib.zz
@@ -35,8 +35,8 @@ enum ParserState {
     PostVal,
 }
 
-export closure Iter      (U *u, err::Err+et mut *e, Parser+pt mut* p, char *k, Value v);
-export closure Pop       (U *u, err::Err+et mut *e, Parser+pt mut* p);
+export closure Iter      (U *u, err::Err mut *e, Parser mut* p, char *k, Value v);
+export closure Pop       (U *u, err::Err mut *e, Parser mut* p);
 
 export struct U {
     Iter    it;
@@ -66,21 +66,21 @@ export struct Parser+ {
     buffer::Buffer+ mut capture;
 }
 
-export fn parser(Parser+tail mut new *self, err::Err+et mut *e, U u)
+export fn parser(Parser mut new *self, err::Err mut *e, U u, usize tail = static(len(self->capture.mem)))
     where err::checked(*e)
     where tail > 1
     where safe(u.it)
 
 {
     memset(self, 0, sizeof(Parser));
-    buffer::clear(&self->capture);
+    buffer::make(&self->capture, tail);
 
     self->line  = 1;
 
     ((self->state)[0]).user   = u;
 }
 
-export fn next(Parser+tail mut*self, err::Err+et mut *e, U u)
+export fn next(Parser mut*self, err::Err mut *e, U u)
     where err::checked(*e)
     where safe(u.it)
 
@@ -100,7 +100,7 @@ export fn next(Parser+tail mut*self, err::Err+et mut *e, U u)
     ((self->state)[self->depth]).user   = u;
 }
 
-export fn close(Parser+tail mut *self, err::Err+et mut *e)
+export fn close(Parser mut *self, err::Err mut *e)
 {
     for (;;) {
         static_attest(self->depth < len(self->state));
@@ -119,12 +119,11 @@ export fn close(Parser+tail mut *self, err::Err+et mut *e)
     }
 }
 
-export fn push(Parser+tail mut *self, err::Err+et mut *e, char *str, usize strlen)
-    @solver("yices2")
+export fn push(Parser mut *self, err::Err mut *e, char *str, usize strlen)
     where err::checked(*e)
     where len(str) >= strlen
-    where tail > 2
 {
+    static_attest(buffer::integrity(&self->capture));
     for (usize mut at = 0; at < strlen; at++) {
         self->col += 1;
 

--- a/modules/toml/src/main.zz
+++ b/modules/toml/src/main.zz
@@ -70,7 +70,7 @@ test test_array {
 
 
 
-fn pretty(toml::U * self, err::Err+et mut *e, toml::Parser+pt mut* p, char *k, toml::Value v)
+fn pretty(toml::U * self, err::Err mut *e, toml::Parser mut* p, char *k, toml::Value v)
     where err::checked(*e)
 {
     for (usize mut i = 0; i < self->user2 * 2; i++) {
@@ -109,7 +109,7 @@ fn pretty(toml::U * self, err::Err+et mut *e, toml::Parser+pt mut* p, char *k, t
     }
 }
 
-fn pop_array(toml::U * self, err::Err+et mut *e, toml::Parser+pt mut* p)
+fn pop_array(toml::U * self, err::Err mut *e, toml::Parser mut* p)
 {
     for (usize mut i = 0; i < (self->user2 - 1) * 2; i++) {
         printf(" ");
@@ -117,7 +117,7 @@ fn pop_array(toml::U * self, err::Err+et mut *e, toml::Parser+pt mut* p)
     printf("]\n");
 }
 
-fn pop_object(toml::U * self, err::Err+et mut *e, toml::Parser+pt mut* p)
+fn pop_object(toml::U * self, err::Err mut *e, toml::Parser mut* p)
 {
     for (usize mut i = 0; i < (self->user2  - 1) * 2; i++) {
         printf(" ");

--- a/modules/toml/tests/print.zz
+++ b/modules/toml/tests/print.zz
@@ -83,7 +83,7 @@ test test_array {
 "#
 }
 
-fn pretty(toml::U * self, err::Err+et mut *e, toml::Parser+pt mut* p, char *k, toml::Value v)
+fn pretty(toml::U * self, err::Err mut *e, toml::Parser mut* p, char *k, toml::Value v)
     where err::checked(*e)
 {
     for (usize mut i = 0; i < self->user2 * 2; i++) {
@@ -122,7 +122,7 @@ fn pretty(toml::U * self, err::Err+et mut *e, toml::Parser+pt mut* p, char *k, t
     }
 }
 
-fn pop_array(toml::U * self, err::Err+et mut *e, toml::Parser+pt mut* p)
+fn pop_array(toml::U * self, err::Err mut *e, toml::Parser mut* p)
 {
     for (usize mut i = 0; i < (self->user2 - 1) * 2; i++) {
         printf(" ");
@@ -130,7 +130,7 @@ fn pop_array(toml::U * self, err::Err+et mut *e, toml::Parser+pt mut* p)
     printf("]\n");
 }
 
-fn pop_object(toml::U * self, err::Err+et mut *e, toml::Parser+pt mut* p)
+fn pop_object(toml::U * self, err::Err mut *e, toml::Parser mut* p)
 {
     for (usize mut i = 0; i < (self->user2  - 1) * 2; i++) {
         printf(" ");

--- a/modules/vec/src/lib.zz
+++ b/modules/vec/src/lib.zz
@@ -26,14 +26,14 @@ export struct Vec+ {
     pool::Pool+ mut pool;
 }
 
-/// create a new vec
+/// create a new vec from tail
 ///
 ///     new+1000 l = vec::make();
-export fn make(Vec+lt mut new* self)
+export fn make(Vec mut new* self, usize lt = static(len(self->pool.pmem)))
     model integrity(self)
 {
     mem::zero(self);
-    self->pool.make(sizeof(slice::Slice));
+    self->pool.make(sizeof(slice::Slice), lt);
     self->capacity = lt/unsafe<usize>(sizeof(slice::Slice) + sizeof(bool))/10;
 
     u8 mut* themem  = self->pool.malloc(unsafe<usize>(sizeof(slice::Slice) + sizeof(bool)) * self->capacity);
@@ -44,7 +44,7 @@ export fn make(Vec+lt mut new* self)
     static_attest(integrity(self))
 }
 
-/// create a new vec with an additional pool
+/// create a new vec from tail and with an additional pool
 ///
 /// the extra pool is used when tail memory is full
 /// you can also use no tail memory at all by setting it to 0
@@ -52,11 +52,11 @@ export fn make(Vec+lt mut new* self)
 ///     new+1000 p = pool::make(8);
 ///     new+0 l = vec::make_with_pool(&p);
 ///
-export fn make_with_pool(Vec+lt mut new* self, pool::Pool mut * pool)
+export fn make_with_pool(Vec mut new* self, pool::Pool mut * pool, usize lt = static(len(self->pool.pmem)))
     model integrity(self)
 {
     mem::zero(self);
-    self->pool.make(sizeof(slice::Slice));
+    self->pool.make(sizeof(slice::Slice), lt);
     self->pool.extra = pool;
     self->capacity = lt/unsafe<usize>(sizeof(slice::Slice) + sizeof(bool))/10;
 
@@ -114,7 +114,7 @@ fn grow(Vec mut* self) bool
 
 /// append owned value
 /// returns false if there is no memory left in the pool
-export fn push(Vec mut* self, void+vt * val) bool
+export fn push(Vec mut* self, void * val, usize vt = static(len(val), 1) * sizeof(*val)) bool
     where !constrained(item(*self)) || typeof(*val) == item(*self)
     where integrity(self)
     model integrity(self)
@@ -122,6 +122,7 @@ export fn push(Vec mut* self, void+vt * val) bool
     u8 mut * owned_val = self->pool.malloc(vt);
     static_attest(safe(owned_val));
     static_attest(len(owned_val) == vt);
+    static_attest(len(val) == vt);
     mem::copy(val, owned_val, vt);
 
     let i = slice::slice::Slice {
@@ -139,7 +140,7 @@ export fn push(Vec mut* self, void+vt * val) bool
 /// append borrowed value
 /// the borrowed references must be valid for the lifetime of the vec
 /// returns false if there is no memory left in the pool to grow the vec
-export fn push_b(Vec mut* self, void+vt * val) bool
+export fn push_b(Vec mut* self, void * val, usize vt = static(len(val), 1) * sizeof(*val)) bool
     where integrity(self)
     model integrity(self)
 {
@@ -165,6 +166,23 @@ fn push_i(Vec mut* self, slice::slice::Slice i, bool owned) bool
     self->count += 1;
     return true;
 }
+
+
+/// get item at position
+export fn get(Vec * self, usize i) void *
+    where integrity(self)
+    where i < self->count
+    model integrity(self)
+    model safe(return)
+    model typeof(*return) == item(*self)
+
+{
+    void * r = self->items[i].mem;
+    static_attest(safe(r));
+    static_attest(typeof(*r) == item(*self));
+    return r;
+}
+
 
 
 /// delete specific item, shifting the vec

--- a/modules/vec/src/main.zz
+++ b/modules/vec/src/main.zz
@@ -5,9 +5,11 @@ using err;
 
 
 export struct A {
+    int d;
 }
 
 export struct B {
+    int d;
 }
 
 export fn main() int {
@@ -18,16 +20,27 @@ export fn main() int {
 
     new+0 l = vec::make_with_pool(&p);
 
+
+
     err::assert(l.push("hello"));
     err::assert(l.push_b("bob"));
 
 
-    err::assert(l.count == 2);
+
+
+    int ar[2] = {0};
+    err::assert(l.push(ar));
+
+    u8 o = 12;
+    l.push(&o);
+
+    err::assert(l.count == 4);
+
     let mut v = l.items[0];
     log::info(">%.*s<", v.size, v.mem);
-
     v = l.items[1];
     log::info(">%.*s<", v.size, v.mem);
+
 
 
     new[vec::item = A, +0] l2 = vec::make_with_pool(&p);
@@ -35,13 +48,28 @@ export fn main() int {
 
     A a;
     l2.push(&a);
-    A a2;
+    A a2 = A{d:99};
     l2.push(&a2);
+
+    err::assert(l2.count == 2);
+    A * a3 = (A*)l2.get(1);
+    err::assert(a3->d == 99);
 
 
     // must not compile
     //B b;
     //l2.push(&b);
+
+
+    new[vec::item = u64, +1000] l3 = vec::make();
+    u64 val = 9;
+    l3.push(&val);
+    err::assert(l3.count == 1);
+    static_assert(typeof(*l3.get(0)) == typeof(u64));
+    u64 val_back = *((u64*)l3.get(0));
+    err::assert(val_back == val);
+
+
 
 
     return 0;

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -5,6 +5,8 @@ use std::collections::HashSet;
 use std::fmt;
 use std::path::PathBuf;
 
+
+#[serde(rename_all = "snake_case")]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize, Default)]
 pub struct Location {
     pub file: String,
@@ -44,9 +46,11 @@ impl std::fmt::Display for Location {
     }
 }
 
+#[serde(rename_all = "snake_case")]
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct Tags(pub HashMap<String, HashMap<String, Location>>);
 
+#[serde(rename_all = "snake_case")]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Storage {
     Static,
@@ -54,6 +58,7 @@ pub enum Storage {
     Atomic,
 }
 
+#[serde(rename_all = "snake_case")]
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub enum Visibility {
     Shared,
@@ -61,6 +66,7 @@ pub enum Visibility {
     Export,
 }
 
+#[serde(rename_all = "snake_case")]
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct Import {
     pub name: Name,
@@ -72,6 +78,7 @@ pub struct Import {
     pub needs: Vec<(Typed, Location)>,
 }
 
+#[serde(rename_all = "snake_case")]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum Tail {
     None,
@@ -86,6 +93,7 @@ impl Default for Tail {
     }
 }
 
+#[serde(rename_all = "snake_case")]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Derive {
     pub loc: Location,
@@ -93,6 +101,7 @@ pub struct Derive {
     pub args: Vec<Box<Expression>>,
 }
 
+#[serde(rename_all = "snake_case")]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Array {
     None,
@@ -100,6 +109,7 @@ pub enum Array {
     Sized(Expression),
 }
 
+#[serde(rename_all = "snake_case")]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Def {
     Static {
@@ -177,6 +187,7 @@ pub enum Def {
     }
 }
 
+#[serde(rename_all = "snake_case")]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Local {
     pub name: String,
@@ -186,12 +197,14 @@ pub struct Local {
     pub doc: String,
 }
 
+#[serde(rename_all = "snake_case")]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Pointer {
     pub loc: Location,
     pub tags: Tags,
 }
 
+#[serde(rename_all = "snake_case")]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum Type {
     Void,
@@ -276,6 +289,7 @@ impl Default for Type {
     }
 }
 
+#[serde(rename_all = "snake_case")]
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct Typed {
     pub t:      Type,
@@ -294,7 +308,7 @@ impl std::fmt::Display for Typed {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self.t {
             Type::Void => write!(f, "void"),
-            Type::Char => write!(f, "i8"), 
+            Type::Char => write!(f, "char"),
             Type::New => write!(f, "new"),
             Type::Elided => write!(f, "elided"),
             Type::U8 => write!(f, "u8"),
@@ -333,6 +347,7 @@ impl std::fmt::Display for Typed {
     }
 }
 
+#[serde(rename_all = "snake_case")]
 #[derive(Default, Clone, Serialize, Deserialize)]
 pub struct Module {
     pub name: Name,
@@ -342,19 +357,23 @@ pub struct Module {
     pub sources: HashSet<PathBuf>,
 }
 
+#[serde(rename_all = "snake_case")]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AnonArg {
     pub typed: Typed,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct NamedArg {
-    pub typed: Typed,
-    pub name: String,
-    pub tags: Tags,
-    pub loc: Location,
+    pub typed:      Typed,
+    pub name:       String,
+    pub tags:       Tags,
+    pub loc:        Location,
+    pub assign:     Option<Expression>,
 }
 
+#[serde(rename_all = "snake_case")]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Field {
     pub typed: Typed,
@@ -364,6 +383,7 @@ pub struct Field {
     pub loc: Location,
 }
 
+#[serde(rename_all = "snake_case")]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum InfixOperator {
     Equals,
@@ -457,6 +477,7 @@ impl InfixOperator {
     }
 }
 
+#[serde(rename_all = "snake_case")]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum PrefixOperator {
     Boolnot,
@@ -467,12 +488,14 @@ pub enum PrefixOperator {
     Deref,
 }
 
+#[serde(rename_all = "snake_case")]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum PostfixOperator {
     Increment,
     Decrement,
 }
 
+#[serde(rename_all = "snake_case")]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum AssignOperator {
     Bitor,
@@ -482,6 +505,7 @@ pub enum AssignOperator {
     Eq,
 }
 
+#[serde(rename_all = "snake_case")]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum EmitBehaviour {
     Default,
@@ -489,6 +513,7 @@ pub enum EmitBehaviour {
     Error { loc: Location, message: String },
 }
 
+#[serde(rename_all = "snake_case")]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Expression {
     Name(Typed),
@@ -591,6 +616,7 @@ impl Expression {
     }
 }
 
+#[serde(rename_all = "snake_case")]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Statement {
     Mark {
@@ -663,11 +689,13 @@ pub enum Statement {
     },
 }
 
+#[serde(rename_all = "snake_case")]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ConditionalBlock {
     pub branches: Vec<(Location, Option<Expression>, Block)>,
 }
 
+#[serde(rename_all = "snake_case")]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Block {
     pub end: Location,

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,6 @@ fn main() {
         std::env::set_var("RUST_LOG", "info");
     }
     env_logger::builder()
-        //.default_format_module_path(false)
         .default_format_timestamp(false)
         .default_format_module_path(false)
         .init();

--- a/src/smt.rs
+++ b/src/smt.rs
@@ -221,6 +221,33 @@ impl Solver {
         self.checkpoint();
     }
 
+    // an invocation using a symbol as literal integer rather than value
+    // this is really just for typeof
+    pub fn meta_invocation(&mut self, theory: Symbol, args: Vec<Symbol>, tmp: TemporalSymbol) {
+        let mut debug_args = Vec::new();
+        for arg in &args {
+            debug_args.push(format!("(_ bv{} 64)\n", arg));
+        }
+
+        let debug_args = debug_args.join(" ");
+        let tmp_debug = self.var(&tmp);
+
+        let theory = &self.theories[&theory];
+
+        if debug_args.len() > 0 {
+            self.solver
+                .borrow_mut()
+                .assert(&format!("(= {} ({} {}) )", tmp_debug, theory, debug_args))
+                .expect(&format!("invocation failed: (= {} ({} {}) )", tmp_debug, theory, debug_args));
+        } else {
+            self.solver
+                .borrow_mut()
+                .assert(&format!("(= {} {})", tmp_debug, theory))
+                .expect(&format!("invocation failed: (= {} {})", tmp_debug, theory));
+        }
+        self.checkpoint();
+    }
+
     pub fn declare(&mut self, sym: Symbol, name: &str, typ: Type) {
         let smtname = format!(
             "var{}_{}",

--- a/src/zz.pest
+++ b/src/zz.pest
@@ -103,8 +103,10 @@ named_typei = _{ type_part  ~ named_typei | ident }
 macro_ident = ${"@" ~ type_name}
 macrocall   = {macro_ident ~ "(" ~ call_args? ~ ")" }
 fn_attr     = {"inline" | "extern"}
-fn_args     = { named_type ~ ( "," ~ named_type )* ~ ( "," ~ vararg)? ~  ","? }
+fn_arg      = { named_type ~ ( "=" ~ expr)? }
+fn_args     = { fn_arg ~ ( "," ~ fn_arg )* ~ ( "," ~ vararg)? ~  ","? }
 ret_arg     = {"->"? ~ anon_type }
+
 call_assert = {"where" ~ expr }
 call_effect = {"model" ~ expr }
 function    = { ( exported | key_shared)? ~ fn_attr* ~ "fn" ~ ident ~ "(" ~ fn_args? ~")" ~ ret_arg? ~ ( macrocall | call_assert | call_effect)* ~ gblock }

--- a/tests/mustfail/callsite_assign_leak/.gitignore
+++ b/tests/mustfail/callsite_assign_leak/.gitignore
@@ -1,0 +1,6 @@
+/target
+.gdb_history
+vgcore.*
+**/*.o
+**/*.parsecache
+**/*.buildcache

--- a/tests/mustfail/callsite_assign_leak/src/main.zz
+++ b/tests/mustfail/callsite_assign_leak/src/main.zz
@@ -1,0 +1,14 @@
+using log;
+
+
+
+export fn twice(int a , int b = 2 * x) int
+{
+    return b;
+}
+
+export fn main() int {
+    int x = 3;
+    log::info("hello %d", twice(2));
+    return 0;
+}

--- a/tests/mustfail/callsite_assign_leak/zz.toml
+++ b/tests/mustfail/callsite_assign_leak/zz.toml
@@ -1,0 +1,13 @@
+[project]
+version = "0.1.0"
+name = "callsite_assign"
+cincludes = []
+cobjects = []
+pkgconfig = []
+cflags = []
+
+[dependencies]
+log = "1"
+mem = "1"
+
+[repos]

--- a/tests/mustpass/alias/.gitignore
+++ b/tests/mustpass/alias/.gitignore
@@ -1,0 +1,6 @@
+/target
+.gdb_history
+vgcore.*
+**/*.o
+**/*.parsecache
+**/*.buildcache

--- a/tests/mustpass/alias/src/main.zz
+++ b/tests/mustpass/alias/src/main.zz
@@ -1,0 +1,22 @@
+using log;
+
+
+
+struct A{
+    int dummy;
+};
+
+theory booze(void _) bool;
+
+export type B = A[booze = true];
+
+export fn main() int {
+
+    B mut b;
+    b.dummy = 3;
+
+    static_assert(booze(b));
+
+    log::info("hello %s", "alias");
+    return 0;
+}

--- a/tests/mustpass/alias/zz.toml
+++ b/tests/mustpass/alias/zz.toml
@@ -1,0 +1,13 @@
+[project]
+version = "0.1.0"
+name = "alias"
+cincludes = []
+cobjects = []
+pkgconfig = []
+cflags = []
+
+[dependencies]
+log = "1"
+mem = "1"
+
+[repos]

--- a/tests/mustpass/callsite_assign/.gitignore
+++ b/tests/mustpass/callsite_assign/.gitignore
@@ -1,0 +1,6 @@
+/target
+.gdb_history
+vgcore.*
+**/*.o
+**/*.parsecache
+**/*.buildcache

--- a/tests/mustpass/callsite_assign/src/main.zz
+++ b/tests/mustpass/callsite_assign/src/main.zz
@@ -1,0 +1,13 @@
+using log;
+
+
+
+export fn twice(int a , int b = 2 * a) int
+{
+    return b;
+}
+
+export fn main() int {
+    log::info("hello %d", twice(2));
+    return 0;
+}

--- a/tests/mustpass/callsite_assign/zz.toml
+++ b/tests/mustpass/callsite_assign/zz.toml
@@ -1,0 +1,13 @@
+[project]
+version = "0.1.0"
+name = "callsite_assign"
+cincludes = []
+cobjects = []
+pkgconfig = []
+cflags = []
+
+[dependencies]
+log = "1"
+mem = "1"
+
+[repos]

--- a/tests/mustpass/callsite_assign_sizeof/.gitignore
+++ b/tests/mustpass/callsite_assign_sizeof/.gitignore
@@ -1,0 +1,6 @@
+/target
+.gdb_history
+vgcore.*
+**/*.o
+**/*.parsecache
+**/*.buildcache

--- a/tests/mustpass/callsite_assign_sizeof/src/main.zz
+++ b/tests/mustpass/callsite_assign_sizeof/src/main.zz
@@ -1,0 +1,28 @@
+using log;
+using err;
+
+fn dump(void * obj, usize expect, usize actual = sizeof(*obj))
+{
+    log::info("dumping object of size %d", actual);
+    err::assert(expect == actual);
+}
+
+struct A {
+    u64 dummy;
+    u64 b[];
+}
+
+export fn main() int {
+
+    u8 a;
+    dump(&a, 1);
+
+    A+1000 b;
+    dump(&b, 8008);
+
+
+    dump(&b, 1000, 1000);
+
+    log::info("hello %s", "callsite_assign_sizeof");
+    return 0;
+}

--- a/tests/mustpass/callsite_assign_sizeof/zz.toml
+++ b/tests/mustpass/callsite_assign_sizeof/zz.toml
@@ -1,0 +1,15 @@
+[project]
+version = "0.1.0"
+name = "callsite_assign_sizeof"
+cincludes = []
+cobjects = []
+pkgconfig = []
+cflags = []
+
+[dependencies]
+mem = "1"
+log = "1"
+err = "1"
+
+[repos]
+

--- a/tests/mustpass/cast_clears_assigned/.gitignore
+++ b/tests/mustpass/cast_clears_assigned/.gitignore
@@ -1,0 +1,6 @@
+/target
+.gdb_history
+vgcore.*
+**/*.o
+**/*.parsecache
+**/*.buildcache

--- a/tests/mustpass/cast_clears_assigned/src/main.zz
+++ b/tests/mustpass/cast_clears_assigned/src/main.zz
@@ -1,0 +1,29 @@
+using log;
+
+
+struct  A{
+    int dummy;
+};
+
+
+
+export fn blah(void *x ) {
+    static_attest(typeof(*x) == typeof(void));
+    static_assert(typeof(*x) == typeof(void));
+
+    A mut *a = (A mut *)x;
+    static_attest(safe(a));
+    a->dummy = 3;
+
+    static_assert(typeof(*a) == typeof(A));
+
+    // TODO once asserted, that's kinda it
+    //static_assert(typeof(*x) == typeof(void));
+
+}
+
+export fn main() int {
+
+    log::info("hello %s", "cast_clears_assigned");
+    return 0;
+}

--- a/tests/mustpass/cast_clears_assigned/zz.toml
+++ b/tests/mustpass/cast_clears_assigned/zz.toml
@@ -1,0 +1,13 @@
+[project]
+version = "0.1.0"
+name = "cast_clears_assigned"
+cincludes = []
+cobjects = []
+pkgconfig = []
+cflags = []
+
+[dependencies]
+log = "1"
+mem = "1"
+
+[repos]

--- a/tests/mustpass/cast_sizes/src/main.zz
+++ b/tests/mustpass/cast_sizes/src/main.zz
@@ -1,10 +1,19 @@
 using <stdio.h>::{printf};
 
+
+struct A{
+    u64 a;
+}
+
+fn bah(u8 mut *a) {
+    u64 b = 33;
+    *a = (u8)b;
+}
+
 export fn main() -> int {
 
     u8 a = 128;
     static_assert(a != 12);
     static_assert(a == 128);
-
     return 0;
 }

--- a/tests/mustpass/tail/src/main.zz
+++ b/tests/mustpass/tail/src/main.zz
@@ -8,6 +8,7 @@ struct Bob+ {
 }
 
 
+// old style generated arg
 fn whutup(Bob+t * bob)
     where t > 10
 {
@@ -16,9 +17,40 @@ fn whutup(Bob+t * bob)
     printf(" the %zu'th integer is %d\n", t-1, x);
 }
 
+// as callsite assign of len
+fn broccoli(Bob * bob, usize t = static(len(bob->b)))
+    where t > 10
+{
+    printf("hello bob and a %zu integers\n", t);
+    int x = (bob->b)[t-1];
+    printf(" the %zu'th integer is %d\n", t-1, x);
+}
+
+// as callsite assign of tailof
+fn yahl(Bob * bob, usize t = static(tailof(*bob)))
+    where t > 10
+{
+    // this would be needed if we did not do type_params_into_ssa earlier
+    //static_attest(t == len(bob->b));
+
+    printf("hello bob and a %zu integers\n", t);
+    int x = (bob->b)[t-1];
+    printf(" the %zu'th integer is %d\n", t-1, x);
+}
+
 export fn main() -> int {
+
     Bob+100 mut b = {0};
+    static_assert(tailof(b) == 100);
+
     (b.b)[99] = 99;
+    static_assert(tailof(b) == 100);
+
+
+
     whutup(&b);
+    broccoli(&b);
+    static_assert(tailof(b) == 100);
+    yahl(&b);
     return 0;
 }

--- a/tests/mustpass/tail_of_static/.gitignore
+++ b/tests/mustpass/tail_of_static/.gitignore
@@ -1,0 +1,6 @@
+/target
+.gdb_history
+vgcore.*
+**/*.o
+**/*.parsecache
+**/*.buildcache

--- a/tests/mustpass/tail_of_static/src/main.zz
+++ b/tests/mustpass/tail_of_static/src/main.zz
@@ -1,0 +1,26 @@
+using log;
+using buffer;
+
+struct A {
+    int a;
+    int b[];
+}
+
+
+
+fn a() {
+    static_attest(buffer::integrity(&stringbuf));
+    stringbuf.push(1);
+}
+
+
+
+static buffer::Buffer+1000 mut stringbuf = {0};
+
+export fn main() int {
+    stringbuf.make();
+
+
+    log::info("hello %s", "tail_of_static");
+    return 0;
+}

--- a/tests/mustpass/tail_of_static/zz.toml
+++ b/tests/mustpass/tail_of_static/zz.toml
@@ -1,0 +1,13 @@
+[project]
+version = "0.1.0"
+name = "tail_of_static"
+cincludes = []
+cobjects = []
+pkgconfig = []
+cflags = []
+
+[dependencies]
+mem = "1"
+log = "1"
+
+[repos]

--- a/tests/mustpass/typeid/src/main.zz
+++ b/tests/mustpass/typeid/src/main.zz
@@ -45,6 +45,8 @@ export fn main() int {
     static_attest(typeof(*a) == bob());
     static_assert(constrained(typeof(*a)));
 
+    static_assert(typeof(u8) == typeof(u8));
+    static_assert(typeof(u8) != typeof(i8));
 
     log::info("hello %s", "typeof");
     return 0;


### PR DESCRIPTION
implements callsite assigns that work similar to "default arguments" in C++
except they are full smt expressions

also introduces the tailof() theory which lets you get and finally also
set a pointers tail. use in combination with callsite assign to replace
tail bindings