### PR TITLE
BREAKING new constructor now uses uninitialized memory

### DIFF
--- a/modules/net/src/address.zz
+++ b/modules/net/src/address.zz
@@ -75,6 +75,7 @@ export fn from_str(Address mut new*self, char * mut s, usize mut slen)
     where len(s) >= slen
 {
     if slen < 2 {
+        none(self);
         return;
     }
 
@@ -87,9 +88,10 @@ export fn from_str(Address mut new*self, char * mut s, usize mut slen)
         return;
     }
 
-    bool unused = (from_str_ipv4(self, s, slen) || from_str_ipv6(self, s, slen));
-    //bug in xtensa-esp32-elf-gcc
-    (void)unused;
+    bool ok = (from_str_ipv4(self, s, slen) || from_str_ipv6(self, s, slen));
+    if !ok {
+        none(self);
+    }
     return;
 }
 


### PR DESCRIPTION
constructor functions are required to use the "new" tag on a pointer,
which also allows uniitialized memorey to be passed (not checked yet)

so far new calls have initialized memory anyway, to prevent some subtle
bugs, but this actually has a big performance hit for large tail memory.

this change will remove to 0 initialization, so any function accepting
a new pointer has to properly initialize it. std has always done this,
but there may be bugs in user code.

the default zz build mode (test) enables ubsan which catches these
errors at runtime, so they should be quick to find.