### PR TITLE
Fix binary literal warning/error in non-GNU compilers

### DIFF
--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -1616,10 +1616,10 @@ impl Emitter {
                     // Output as decimal if an integer to avoid warnings for binary literals
                     // (binary literals are a GNU extension)
                     Some(parser::Integer::Signed(int)) => {
-                        write!(self.f, "    {}", int).unwrap();
+                        write!(self.f, "    {:#x}", int).unwrap();
                     }
                     Some(parser::Integer::Unsigned(int)) => {
-                        write!(self.f, "    {}", int).unwrap();
+                        write!(self.f, "    {:#x}", int).unwrap();
                     }
                     // If the literal is not an integer (boolean literals, for example), write
                     // it as-is

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -1612,7 +1612,21 @@ impl Emitter {
             }
             ast::Expression::Literal { loc, v } => {
                 self.emit_loc(&loc);
-                write!(self.f, "    {}", v).unwrap();
+                match parser::parse_int(&v) {
+                    // Output as decimal if an integer to avoid warnings for binary literals
+                    // (binary literals are a GNU extension)
+                    Some(parser::Integer::Signed(int)) => {
+                        write!(self.f, "    {}", int).unwrap();
+                    }
+                    Some(parser::Integer::Unsigned(int)) => {
+                        write!(self.f, "    {}", int).unwrap();
+                    }
+                    // If the literal is not an integer (boolean literals, for example), write
+                    // it as-is
+                    None => {
+                        write!(self.f, "    {}", v).unwrap();
+                    }
+                }
             }
             ast::Expression::Call {
                 loc,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2097,6 +2097,7 @@ fn flip_sign(int: Option<Integer>) -> Option<Integer> {
 /// assert_eq!(parse_int("0b101").unwrap(), Unsigned(0b101));
 /// assert_eq!(parse_int("123").unwrap(), Unsigned(123));
 /// assert_eq!(parse_int("-0b101").unwrap(), Signed(-0b101));
+/// assert_eq!(parse_int("-0B101").unwrap(), Signed(-0b101));
 /// assert_eq!(parse_int("-0x10000").unwrap(), Signed(-0x10000));
 /// assert_eq!(parse_int("-0X123A5").unwrap(), Signed(-0x123A5));
 /// assert_eq!(parse_int("-0XF23A5").unwrap(), Signed(-0xF23A5));
@@ -2114,7 +2115,7 @@ pub fn parse_int(s: &str) -> Option<Integer> {
         Some('-') => flip_sign(parse_int(&s[1..])),
         Some('0') => match chars.next() {
             Some('x') | Some('X') => u64::from_str_radix(&s[2..], 16).map(Integer::Unsigned).ok(),
-            Some('b') => u64::from_str_radix(&s[2..], 2).map(Integer::Unsigned).ok(),
+            Some('b') | Some('B') => u64::from_str_radix(&s[2..], 2).map(Integer::Unsigned).ok(),
             Some('0'..='7') => None, // TODO: Octal?
             Some(_) => None, // Invalid "octal" literal
             None => Some(Integer::Unsigned(0)),

--- a/src/zz.pest
+++ b/src/zz.pest
@@ -27,7 +27,7 @@ char_literal    = @{ "'" ~ ( "''" | "\\'" | (!"'" ~ ANY) )* ~ "'" }
 number_literal  = @{ hex_literal | bit_literal | (int_literal ~ ("." ~ digit*)? ~ (^"e" ~ int_literal)?) }
 int_literal     = @{ ("+" | "-")? ~ digit+ }
 hex_literal     = @{ ("0x" | "0X")  ~ hexdigit+ }
-bit_literal     = @{ "0b"  ~ bitdigit+ }
+bit_literal     = @{ ("0b" | "0B")  ~ bitdigit+ }
 
 // keywords
 


### PR DESCRIPTION
Since binary literals aren't a part of the C standard, support for them ranges from nonexistent in some compilers, a warning in some (for example clang) and only truly supported in gcc (with the GNU extensions enabled). This is obviously not great for compatibility, so this commit normalizes all integer literals to decimal.

Examples of warning output by clang:
```
/home/jam/dev/zetz/zetzstd/src/main.zz:55:25: warning: binary integer literals are a GNU extension [-Wgnu-binary-literal]
  return (    desc &    0b11  );
                        ^
/home/jam/dev/zetz/zetzstd/src/main.zz:20:37: warning: binary integer literals are a GNU extension [-Wgnu-binary-literal]
  return ((    desc >>    6  ) &    0b11  );
```

Looking into this also brought to my attention that `0B` is a valid prefix for binary literals under the GNU extension which binary literal support is presumably derived from (alternatively, Go also supports it). It is notable, however, that Rust does not support this prefix.