### PR TITLE
Remove all compiler warnings

### DIFF
--- a/src/abs.rs
+++ b/src/abs.rs
@@ -946,16 +946,18 @@ pub fn abs(
                     scope.insert(ast.name.clone(), ns, &ast.loc, false, true);
                 }
                 ast::Def::Enum { names, .. } => {
-                    let mut value = 0;
-                    for (_, val) in names.iter_mut() {
-                        if let Some(val) = val {
-                            value = *val;
-                        } else {
-                            *val = Some(value);
+                    {
+                        let mut value = 0;
+                        for (_, val) in names.iter_mut() {
+                            if let Some(val) = val {
+                                value = *val;
+                            } else {
+                                *val = Some(value);
+                            }
+                            value += 1;
                         }
-                        value += 1;
                     }
-                    for (name, value) in names {
+                    for (name, _value) in names {
                         let subname = format!("{}::{}", ast.name, name);
 
                         //new_locals.push(ast::Local {

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -9,7 +9,6 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
-use std::io::Write;
 
 #[derive(Clone)]
 pub enum Module {

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,7 +193,7 @@ fn main() {
             let variant = submatches.value_of("variant").unwrap_or("default");
             let stage = zz::make::Stage::test();
             zz::build(zz::BuildSet::Tests, variant, stage.clone(), false);
-            let (root, mut project) = zz::project::load_cwd();
+            let (_root, mut project) = zz::project::load_cwd();
 
             for artifact in std::mem::replace(&mut project.artifacts, None).expect("no artifacts") {
                 if let zz::project::ArtifactType::Test = artifact.typ {
@@ -363,7 +363,7 @@ fn main() {
             };
             let variant = submatches.value_of("variant").unwrap_or("default");
             zz::build(zz::BuildSet::Run, variant, stage.clone(), false);
-            let (root, mut project) = zz::project::load_cwd();
+            let (_root, mut project) = zz::project::load_cwd();
 
             let mut exes = Vec::new();
             for artifact in std::mem::replace(&mut project.artifacts, None).expect("no artifacts") {
@@ -395,7 +395,7 @@ fn main() {
             let variant = submatches.value_of("variant").unwrap_or("default");
             let stage = zz::make::Stage::fuzz();
             zz::build(zz::BuildSet::Tests, variant, stage.clone(), false);
-            let (root, mut project) = zz::project::load_cwd();
+            let (_root, mut project) = zz::project::load_cwd();
 
             let mut exes = Vec::new();
             for artifact in std::mem::replace(&mut project.artifacts, None).expect("no artifacts") {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -382,7 +382,7 @@ impl Pipeline {
     fn pb_reset(&self) {
         let mut pb = pbr::ProgressBar::new(self.modules.len() as u64);
         pb.show_speed = false;
-        std::mem::replace(&mut *self.pb.lock().unwrap(), pb);
+        let _ = std::mem::replace(&mut *self.pb.lock().unwrap(), pb);
     }
 
     fn pb_doing(&self, action: &str, on: String) {


### PR DESCRIPTION
Hi,

This pull request removes all warnings from zz when compiling. It does not change any logic in the code.

It also makes sure errors cannot be introduced. For example, `value` was renamed to `_value` because it was unused. But some commented out code refers to it as "value", which is defined in the previous for loop. By putting this loop into its ownscope, we ensure that anybody re-introducing this code would have to make sure to rename `_value` to `value` back.